### PR TITLE
Add Circles RPC Rust client crate with pagination, WS hooks, and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,12 +273,14 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -296,6 +298,28 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f77d20cdbb68a614c7a86b3ffef607b37d087bb47a03c58f4c3f8f99bc3ace3b"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
  "wasmtimer",
 ]
 
@@ -329,8 +353,10 @@ checksum = "31c89883fe6b7381744cbe80fef638ac488ead4f1956a4278956a1362c71cd2e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "futures",
  "pin-project",
  "reqwest",
@@ -542,6 +568,24 @@ dependencies = [
  "tower",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c9ab4c199e3a8f3520b60ba81aa67bb21fed9ed0d8304e0569094d0758a56f"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http",
+ "rustls",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -813,6 +857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +907,12 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
@@ -1039,6 +1100,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "circles-rpc"
+version = "0.1.0"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-transport-http",
+ "alloy-transport-ws",
+ "circles-types",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "circles-types"
 version = "0.2.1"
 dependencies = [
@@ -1212,6 +1291,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
@@ -2413,6 +2498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,12 +2930,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2990,6 +3110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3209,17 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3433,6 +3570,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,6 +3589,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3570,6 +3733,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,6 +3810,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -3766,6 +3954,24 @@ checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4003,6 +4209,25 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.1",
+ "send_wrapper",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/types", "crates/pathfinder", "crates/abis"]
+members = ["crates/types", "crates/pathfinder", "crates/abis", "crates/rpc"]
 
 [workspace.dependencies]
 # Shared dependencies across all crates

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "circles-rpc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+alloy-json-rpc = "1.1.2"
+alloy-primitives = { workspace = true }
+alloy-provider = { version = "1.1.2", features = ["reqwest"] }
+alloy-transport-http = "1.1.2"
+alloy-transport-ws = { version = "1.1.2", optional = true }
+circles-types = { workspace = true }
+futures = "0.3"
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = "1.0"
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[features]
+default = ["ws"]
+ws = ["dep:alloy-transport-ws", "alloy-provider/pubsub", "alloy-provider/ws"]

--- a/crates/rpc/README.md
+++ b/crates/rpc/README.md
@@ -1,0 +1,110 @@
+# Circles RPC (Rust)
+
+Async JSON-RPC client for the Circles protocol, mirroring the TypeScript SDK’s `@rpc` package while leaning on Alloy transports and shared Circles types.
+
+## Features
+
+- Thin `CirclesRpc` facade with method groups (`balance`, `token`, `trust`, `avatar`, `query`, `events`, `invitation`, `pathfinder`, `group`, `tables`, `health`, `network`, `search`).
+- Uses `alloy-provider` for HTTP; WebSocket subscriptions are available behind the `ws` feature (best-effort `eth_unsubscribe` on drop).
+- `TryFrom<&str>` / `From<reqwest::Url>` constructors instead of bespoke builders.
+- `circles_query` helpers with cursor extraction and `PagedQuery`/`paged_stream` convenience.
+- Normalized token holder balances (`TokenHolderNormalized`) and invitation batching with bounded concurrency.
+
+## Quickstart
+
+```rust
+use circles_rpc::CirclesRpc;
+use circles_types::Address;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let rpc = CirclesRpc::try_from("https://rpc.helsinki.aboutcircles.com/")?;
+
+    // Total balance (v2)
+    let addr: Address = "0xde374ece6fa50e781e81aac78e811b33d16912c7".parse()?;
+    let total = rpc.balance().get_total_balance(addr, false, true).await?;
+    println!("total v2 balance: {}", total.0);
+
+    // Token holders (normalized U256 balances)
+    let holders = rpc.token().get_token_holders(addr).await?;
+    println!("holders count: {}", holders.len());
+
+    Ok(())
+}
+```
+
+## Paged queries
+
+```rust
+use circles_rpc::CirclesRpc;
+use circles_types::{PagedQueryParams, SortOrder, Address};
+
+#[derive(Debug, serde::Deserialize)]
+struct AvatarRow { avatar: Address, timestamp: u64 }
+
+async fn first_page(rpc: &CirclesRpc) -> circles_rpc::Result<()> {
+    let params = PagedQueryParams {
+        namespace: "V_Crc".into(),
+        table: "Avatars".into(),
+        sort_order: SortOrder::DESC,
+        columns: vec![],
+        filter: None,
+        limit: 50,
+    };
+
+    // Pull one page
+    let mut pager = rpc.paged_query::<AvatarRow>(params.clone());
+    if let Some(page) = pager.next_page().await? {
+        println!("fetched {} rows, has_more={}", page.items.len(), page.has_more);
+    }
+
+    // Or stream rows
+    let mut stream = rpc.paged_stream::<AvatarRow>(params);
+    while let Some(row) = stream.next().await.transpose()? {
+        println!("row: {:?}", row);
+    }
+    Ok(())
+}
+```
+
+## Events
+
+HTTP fetch:
+
+```rust
+let events = rpc
+    .events()
+    .circles_events(Some(addr), 0, None, None)
+    .await?;
+```
+
+WebSocket subscription (enable the `ws` feature):
+
+```rust
+#[cfg(feature = "ws")]
+{
+    let sub = rpc.events().subscribe_parsed_events(serde_json::json!({ "address": addr })).await?;
+    tokio::pin!(sub);
+    while let Some(evt) = sub.next().await.transpose()? {
+        println!("event: {:?}", evt.event_type);
+    }
+}
+```
+
+## Status / TODO
+
+- Subscription resilience (reconnect/backoff, pending cleanup) is best-effort today.
+- Pagination helpers are stable but could gain table-aware defaults and richer ergonomics.
+- Transaction/transfer RPCs are intentionally omitted; handled by a separate crate in this workspace.
+
+## Examples
+
+- `paged_and_ws`: fetch one page of avatars via `circles_query` and, with the `ws` feature, subscribe to Circles events.
+
+```bash
+CIRCLES_RPC_URL=https://rpc.aboutcircles.com/ \
+  CIRCLES_RPC_WS_URL=wss://rpc.aboutcircles.com/ws \
+  cargo run -p circles-rpc --example paged_and_ws --features ws
+```
+
+The WS example is best-effort: if the endpoint denies pubsub or no events arrive within a short timeout, it will log and exit gracefully.

--- a/crates/rpc/examples/paged_and_ws.rs
+++ b/crates/rpc/examples/paged_and_ws.rs
@@ -1,0 +1,121 @@
+//! Minimal example hitting the public Circles RPC:
+//! - paged `circles_query` over V_Crc.Avatars
+//! - optional websocket subscription for Circles events
+//!
+//! Run with:
+//! `CIRCLES_RPC_URL=https://rpc.aboutcircles.com/ cargo run -p circles-rpc --example paged_and_ws --features ws`
+
+use circles_rpc::CirclesRpc;
+use circles_rpc::Result;
+use circles_types::{Address, PagedQueryParams, SortOrder};
+use futures::StreamExt;
+use serde::Deserialize;
+use std::time::Duration;
+
+const DEFAULT_RPC_URL: &str = "https://rpc.aboutcircles.com/";
+const DEFAULT_WS_URL: &str = "wss://rpc.aboutcircles.com/ws";
+// Sample address from docs; replace with any avatar you care about.
+const SAMPLE_AVATAR: &str = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+
+#[derive(Debug, Deserialize, serde::Serialize, Clone)]
+struct AvatarRow {
+    avatar: Address,
+    timestamp: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let rpc_url = std::env::var("CIRCLES_RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_string());
+    let rpc = CirclesRpc::try_from(rpc_url.as_str())?;
+
+    let avatar: Address = SAMPLE_AVATAR.parse().expect("valid sample address");
+
+    // --- Paged query example (first page) ---
+    let params = PagedQueryParams {
+        namespace: "V_Crc".to_string(),
+        table: "Avatars".to_string(),
+        sort_order: SortOrder::DESC,
+        columns: vec!["avatar".into(), "timestamp".into()],
+        filter: None,
+        limit: 10,
+    };
+
+    let mut pager = rpc.paged_query::<AvatarRow>(params);
+    if let Some(page) = pager.next_page().await? {
+        println!(
+            "Fetched {} avatar rows (has_more={})",
+            page.items.len(),
+            page.has_more
+        );
+        for row in page.items {
+            println!("avatar {} @ {}", row.avatar, row.timestamp);
+        }
+    } else {
+        println!("No rows returned");
+    }
+
+    // --- WebSocket events example (requires `ws` feature) ---
+    #[cfg(feature = "ws")]
+    {
+        let ws_url =
+            std::env::var("CIRCLES_RPC_WS_URL").unwrap_or_else(|_| DEFAULT_WS_URL.to_string());
+        match CirclesRpc::try_from_ws(ws_url.as_str()).await {
+            Ok(rpc_ws) => stream_events(&rpc_ws, avatar).await?,
+            Err(e) => println!("WebSocket connect failed, skipping subscription: {e}"),
+        }
+    }
+    #[cfg(not(feature = "ws"))]
+    {
+        println!("WebSocket example skipped; enable the `ws` feature to run it.");
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "ws")]
+async fn stream_events(rpc: &CirclesRpc, address: Address) -> Result<()> {
+    use tokio::time::timeout;
+
+    println!("Subscribing to Circles events for address {address}");
+    let filter = serde_json::json!({ "address": address });
+    let mut sub = match rpc.events().subscribe_parsed_events(filter).await {
+        Ok(sub) => sub,
+        Err(e) => {
+            eprintln!("subscription failed: {e}");
+            return Ok(());
+        }
+    };
+
+    let mut seen = 0u32;
+    loop {
+        match timeout(Duration::from_secs(15), sub.next()).await {
+            Ok(Some(Ok(evt))) => {
+                println!(
+                    "event: {:?} @ block {}",
+                    evt.event_type, evt.base.block_number
+                );
+                seen += 1;
+                if seen >= 3 {
+                    break;
+                }
+            }
+            Ok(Some(Err(e))) => {
+                println!("event stream error: {e}");
+                break;
+            }
+            Ok(None) => {
+                println!("subscription closed");
+                break;
+            }
+            Err(_) => {
+                println!("no events within timeout, stopping");
+                break;
+            }
+        }
+    }
+
+    println!("Unsubscribing after {seen} events");
+    // Drop will best-effort eth_unsubscribe, but explicit is fine too.
+    let _ = sub.unsubscribe();
+    Ok(())
+}

--- a/crates/rpc/src/client.rs
+++ b/crates/rpc/src/client.rs
@@ -1,0 +1,69 @@
+use crate::error::{CirclesRpcError, Result};
+use alloy_json_rpc::{RpcRecv, RpcSend};
+#[cfg(feature = "ws")]
+use alloy_provider::GetSubscription;
+use alloy_provider::{Identity, Provider, ProviderBuilder, RootProvider};
+#[cfg(feature = "ws")]
+use alloy_transport_ws::WsConnect;
+use serde::de::DeserializeOwned;
+use std::borrow::Cow;
+
+/// Thin wrapper around an Alloy provider. This will be expanded with WebSocket support
+/// and reconnection logic as we port the TypeScript client behavior.
+#[derive(Clone, Debug)]
+pub struct RpcClient {
+    provider: RootProvider,
+}
+
+impl RpcClient {
+    /// Create a client from an existing provider.
+    pub fn new(provider: RootProvider) -> Self {
+        Self { provider }
+    }
+
+    /// Build a client from an HTTP URL using the vanilla provider (no fillers).
+    pub fn http(url: reqwest::Url) -> Self {
+        let provider: RootProvider =
+            ProviderBuilder::<Identity, Identity>::default().connect_http(url);
+        Self { provider }
+    }
+
+    /// Build a client from a WebSocket URL (requires the `ws` feature).
+    #[cfg(feature = "ws")]
+    pub async fn ws(url: reqwest::Url) -> Result<Self> {
+        let provider: RootProvider = ProviderBuilder::<Identity, Identity>::default()
+            .connect_ws(WsConnect::new(url.to_string()))
+            .await?;
+        Ok(Self { provider })
+    }
+
+    /// Perform a JSON-RPC call using typed params and response.
+    pub async fn call<Req, Resp>(&self, method: &str, params: Req) -> Result<Resp>
+    where
+        Req: RpcSend,
+        Resp: RpcRecv + DeserializeOwned,
+    {
+        let method: Cow<'static, str> = Cow::Owned(method.to_string());
+        self.provider
+            .raw_request(method, params)
+            .await
+            .map_err(CirclesRpcError::from)
+    }
+
+    /// Access the inner provider. This is useful for lower-level calls or subscriptions.
+    pub fn provider(&self) -> &RootProvider {
+        &self.provider
+    }
+}
+
+#[cfg(feature = "ws")]
+impl RpcClient {
+    /// Subscribe via `eth_subscribe` with arbitrary params. Returns an Alloy subscription handle.
+    pub fn subscribe<P, R>(&self, params: P) -> Result<GetSubscription<P, R>>
+    where
+        P: RpcSend,
+        R: RpcRecv,
+    {
+        Ok(self.provider.subscribe(params))
+    }
+}

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,0 +1,22 @@
+use alloy_provider::transport::TransportError;
+use thiserror::Error;
+
+/// Result alias for the Circles RPC crate.
+pub type Result<T> = std::result::Result<T, CirclesRpcError>;
+
+/// Top-level error type for Circles RPC operations.
+#[derive(Debug, Error)]
+pub enum CirclesRpcError {
+    /// Underlying provider/transport error.
+    #[error(transparent)]
+    Transport(#[from] TransportError),
+    /// (De)serialization issues.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    /// Unexpected or malformed response payload.
+    #[error("invalid response: {message}")]
+    InvalidResponse { message: String },
+    /// WebSocket subscription closed unexpectedly.
+    #[error("subscription closed")]
+    SubscriptionClosed,
+}

--- a/crates/rpc/src/events/mod.rs
+++ b/crates/rpc/src/events/mod.rs
@@ -1,0 +1,60 @@
+use crate::error::{CirclesRpcError, Result};
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+
+pub mod parser;
+pub mod subscription;
+
+/// Thin wrapper around subscription streams. Automatically maps transport errors
+/// into `CirclesRpcError` and erases the underlying stream type.
+pub struct EventStream<T> {
+    inner: Pin<Box<dyn Stream<Item = Result<T>> + Send>>,
+}
+
+impl<T> EventStream<T> {
+    pub fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<T>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+
+    /// Access the inner stream if needed.
+    pub fn into_inner(self) -> Pin<Box<dyn Stream<Item = Result<T>> + Send>> {
+        self.inner
+    }
+}
+
+impl<T> Stream for EventStream<T> {
+    type Item = Result<T>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+#[cfg(feature = "ws")]
+impl<T> EventStream<T>
+where
+    T: alloy_json_rpc::RpcRecv + serde::de::DeserializeOwned + Send + 'static,
+{
+    /// Build an `EventStream` from an Alloy subscription handle. Returns the stream and subscription id.
+    pub async fn from_subscription<P>(
+        subscription: alloy_provider::GetSubscription<P, T>,
+    ) -> Result<(Self, alloy_primitives::B256)>
+    where
+        P: alloy_json_rpc::RpcSend + 'static,
+    {
+        let subscription = subscription.await.map_err(CirclesRpcError::from)?;
+        let id = *subscription.local_id();
+        let stream = subscription
+            .into_result_stream()
+            .map(|res| res.map_err(CirclesRpcError::from));
+        Ok((EventStream::new(stream), id))
+    }
+}

--- a/crates/rpc/src/events/parser.rs
+++ b/crates/rpc/src/events/parser.rs
@@ -32,19 +32,18 @@ pub fn parse(event: RpcSubscriptionEvent) -> Result<CirclesEvent, serde_json::Er
 
 fn parse_event_type(raw: &str) -> Result<CirclesEventType, serde_json::Error> {
     // First try as-is using serde's rename mapping.
-    if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{}\"", raw)) {
+    if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{raw}\"")) {
         return Ok(et);
     }
     // Try inserting an underscore after namespace prefix (e.g., CrcV2RegisterHuman -> CrcV2_RegisterHuman).
     if raw.starts_with("CrcV2") && !raw.contains('_') {
         let alt = format!("CrcV2_{}", &raw[5..]);
-        if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{}\"", alt)) {
+        if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{alt}\"")) {
             return Ok(et);
         }
     }
     Err(serde_json::Error::custom(format!(
-        "unknown event type: {}",
-        raw
+        "unknown event type: {raw}"
     )))
 }
 

--- a/crates/rpc/src/events/parser.rs
+++ b/crates/rpc/src/events/parser.rs
@@ -1,0 +1,68 @@
+use circles_types::{CirclesBaseEvent, CirclesEvent, CirclesEventType, RpcSubscriptionEvent};
+use serde::de::Error as DeError;
+use std::collections::HashMap;
+
+/// Parse a raw RpcSubscriptionEvent into a typed CirclesEvent without losing bytes.
+pub fn parse(event: RpcSubscriptionEvent) -> Result<CirclesEvent, serde_json::Error> {
+    let mut values = event.values;
+
+    // Extract base fields.
+    let block_number = take_u64(&mut values, "blockNumber");
+    let transaction_index = take_u32(&mut values, "transactionIndex");
+    let log_index = take_u32(&mut values, "logIndex");
+    let timestamp = take_u64(&mut values, "timestamp");
+    let transaction_hash = take_str(&mut values, "transactionHash").and_then(|s| s.parse().ok());
+
+    let base = CirclesBaseEvent {
+        block_number: block_number.unwrap_or_default(),
+        timestamp,
+        transaction_index: transaction_index.unwrap_or_default(),
+        log_index: log_index.unwrap_or_default(),
+        transaction_hash,
+    };
+
+    let event_type = parse_event_type(&event.event)?;
+
+    Ok(CirclesEvent {
+        base,
+        event_type,
+        data: values,
+    })
+}
+
+fn parse_event_type(raw: &str) -> Result<CirclesEventType, serde_json::Error> {
+    // First try as-is using serde's rename mapping.
+    if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{}\"", raw)) {
+        return Ok(et);
+    }
+    // Try inserting an underscore after namespace prefix (e.g., CrcV2RegisterHuman -> CrcV2_RegisterHuman).
+    if raw.starts_with("CrcV2") && !raw.contains('_') {
+        let alt = format!("CrcV2_{}", &raw[5..]);
+        if let Ok(et) = serde_json::from_str::<CirclesEventType>(&format!("\"{}\"", alt)) {
+            return Ok(et);
+        }
+    }
+    Err(serde_json::Error::custom(format!(
+        "unknown event type: {}",
+        raw
+    )))
+}
+
+fn take_u64(map: &mut HashMap<String, serde_json::Value>, key: &str) -> Option<u64> {
+    map.remove(key).and_then(|v| match v {
+        serde_json::Value::Number(n) => n.as_u64(),
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    })
+}
+
+fn take_u32(map: &mut HashMap<String, serde_json::Value>, key: &str) -> Option<u32> {
+    take_u64(map, key).map(|v| v as u32)
+}
+
+fn take_str(map: &mut HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+    map.remove(key).and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s),
+        _ => None,
+    })
+}

--- a/crates/rpc/src/events/subscription.rs
+++ b/crates/rpc/src/events/subscription.rs
@@ -1,0 +1,50 @@
+use crate::error::{CirclesRpcError, Result};
+use crate::events::EventStream;
+use alloy_primitives::B256;
+use alloy_provider::RootProvider;
+use futures::Stream;
+
+/// Wrapper around an [`EventStream`] that will best-effort `eth_unsubscribe` on drop.
+pub struct CirclesSubscription<T> {
+    stream: EventStream<T>,
+    id: B256,
+    provider: RootProvider,
+}
+
+impl<T> CirclesSubscription<T> {
+    /// Construct a new subscription wrapper from a stream and subscription id.
+    pub fn new(stream: EventStream<T>, id: B256, provider: RootProvider) -> Self {
+        Self {
+            stream,
+            id,
+            provider,
+        }
+    }
+
+    /// Explicitly unsubscribe. Consumes the subscription.
+    pub fn unsubscribe(self) -> Result<()> {
+        self.provider
+            .unsubscribe(self.id)
+            .map_err(CirclesRpcError::from)
+    }
+}
+
+impl<T> Drop for CirclesSubscription<T> {
+    fn drop(&mut self) {
+        let _ = self.provider.unsubscribe(self.id);
+    }
+}
+
+impl<T> Stream for CirclesSubscription<T>
+where
+    EventStream<T>: Stream<Item = Result<T>>,
+{
+    type Item = Result<T>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        std::pin::Pin::new(&mut self.stream).poll_next(cx)
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,0 +1,24 @@
+//! Circles RPC client crate (work in progress).
+//!
+//! This crate will provide an async JSON-RPC client for the Circles protocol,
+//! mirroring the TypeScript SDK surface while relying on Alloy transports and
+//! shared `circles-types` definitions.
+
+pub mod client;
+pub mod error;
+pub mod events;
+pub mod methods;
+pub mod paged_query;
+pub mod rpc;
+pub mod utils;
+
+pub use client::RpcClient;
+pub use error::{CirclesRpcError, Result};
+pub use events::EventStream;
+pub use methods::{
+    AvatarMethods, BalanceMethods, EventsMethods, GroupMethods, HealthMethods, InvitationMethods,
+    NetworkMethods, PathfinderMethods, QueryMethods, SearchMethods, TablesMethods,
+    TokenInfoMethods, TokenMethods, TrustMethods,
+};
+pub use paged_query::{Page, PagedQuery};
+pub use rpc::CirclesRpc;

--- a/crates/rpc/src/methods/avatar.rs
+++ b/crates/rpc/src/methods/avatar.rs
@@ -1,0 +1,69 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{Address, AvatarInfo, Profile};
+
+/// Methods for avatar/profile lookups.
+#[derive(Clone, Debug)]
+pub struct AvatarMethods {
+    client: RpcClient,
+}
+
+impl AvatarMethods {
+    /// Create a new accessor for avatar/profile RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getAvatarInfo
+    pub async fn get_avatar_info(&self, address: Address) -> Result<AvatarInfo> {
+        self.client.call("circles_getAvatarInfo", (address,)).await
+    }
+
+    /// circles_getAvatarInfoBatch
+    pub async fn get_avatar_info_batch(&self, addresses: Vec<Address>) -> Result<Vec<AvatarInfo>> {
+        self.client
+            .call("circles_getAvatarInfoBatch", (addresses,))
+            .await
+    }
+
+    /// circles_getProfileCid
+    pub async fn get_profile_cid(&self, address: Address) -> Result<String> {
+        self.client.call("circles_getProfileCid", (address,)).await
+    }
+
+    /// circles_getProfileCidBatch
+    pub async fn get_profile_cid_batch(&self, addresses: Vec<Address>) -> Result<Vec<String>> {
+        self.client
+            .call("circles_getProfileCidBatch", (addresses,))
+            .await
+    }
+
+    /// circles_getProfileByCid
+    pub async fn get_profile_by_cid(&self, cid: String) -> Result<Profile> {
+        self.client.call("circles_getProfileByCid", (cid,)).await
+    }
+
+    /// circles_getProfileByCidBatch
+    pub async fn get_profile_by_cid_batch(&self, cids: Vec<String>) -> Result<Vec<Profile>> {
+        self.client
+            .call("circles_getProfileByCidBatch", (cids,))
+            .await
+    }
+
+    /// circles_getProfileByAddress
+    pub async fn get_profile_by_address(&self, address: Address) -> Result<Profile> {
+        self.client
+            .call("circles_getProfileByAddress", (address,))
+            .await
+    }
+
+    /// circles_getProfileByAddressBatch
+    pub async fn get_profile_by_address_batch(
+        &self,
+        addresses: Vec<Address>,
+    ) -> Result<Vec<Profile>> {
+        self.client
+            .call("circles_getProfileByAddressBatch", (addresses,))
+            .await
+    }
+}

--- a/crates/rpc/src/methods/balance.rs
+++ b/crates/rpc/src/methods/balance.rs
@@ -1,0 +1,31 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{Address, Balance};
+
+/// Methods for aggregate balance queries.
+#[derive(Clone, Debug)]
+pub struct BalanceMethods {
+    client: RpcClient,
+}
+
+impl BalanceMethods {
+    /// Create a new accessor for balance RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getTotalBalance / circlesV2_getTotalBalance
+    pub async fn get_total_balance(
+        &self,
+        address: Address,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Balance> {
+        let method = if use_v2 {
+            "circlesV2_getTotalBalance"
+        } else {
+            "circles_getTotalBalance"
+        };
+        self.client.call(method, (address, as_time_circles)).await
+    }
+}

--- a/crates/rpc/src/methods/events.rs
+++ b/crates/rpc/src/methods/events.rs
@@ -1,0 +1,83 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use crate::events::EventStream;
+use crate::events::subscription::CirclesSubscription;
+use alloy_json_rpc::RpcSend;
+use circles_types::{CirclesEvent, RpcSubscriptionEvent};
+use futures::StreamExt;
+
+/// Methods for fetching Circles events over HTTP or websocket.
+#[derive(Clone, Debug)]
+pub struct EventsMethods {
+    client: RpcClient,
+}
+
+impl EventsMethods {
+    /// Create a new accessor for event-related RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// HTTP: `circles_events(address, fromBlock, toBlock?, filter?)`
+    pub async fn circles_events(
+        &self,
+        address: Option<circles_types::Address>,
+        from_block: u64,
+        to_block: Option<u64>,
+        filter: Option<Vec<circles_types::Filter>>,
+    ) -> Result<Vec<CirclesEvent>> {
+        let params = (address, from_block, to_block, filter);
+        let raw: Vec<RpcSubscriptionEvent> = self.client.call("circles_events", params).await?;
+        raw.into_iter()
+            .map(|e| {
+                crate::events::parser::parse(e).map_err(|err| {
+                    crate::error::CirclesRpcError::InvalidResponse {
+                        message: err.to_string(),
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Subscribe via `eth_subscribe("circles", filter)` and yield raw `RpcSubscriptionEvent`s.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_circles_events<F>(
+        &self,
+        filter: F,
+    ) -> Result<CirclesSubscription<RpcSubscriptionEvent>>
+    where
+        F: RpcSend + 'static,
+    {
+        let provider = self.client.provider().clone();
+        let sub = self.client.subscribe(("circles", filter))?;
+        let (stream, id) = EventStream::from_subscription(sub).await?;
+        Ok(CirclesSubscription::new(stream, id, provider))
+    }
+
+    /// Subscribe and parse into `CirclesEvent` using the canonical parser.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_parsed_events<F>(
+        &self,
+        filter: F,
+    ) -> Result<CirclesSubscription<CirclesEvent>>
+    where
+        F: RpcSend + 'static,
+    {
+        let provider = self.client.provider().clone();
+        let sub = self.client.subscribe(("circles", filter))?;
+        let (raw_stream, id) = EventStream::from_subscription(sub).await?;
+        let mapped = raw_stream.into_inner().map(|item| match item {
+            Ok(raw) => crate::events::parser::parse(raw).map_err(|e| {
+                crate::error::CirclesRpcError::InvalidResponse {
+                    message: e.to_string(),
+                }
+            }),
+            Err(e) => Err(e),
+        });
+        Ok(CirclesSubscription::new(
+            EventStream::new(mapped),
+            id,
+            provider,
+        ))
+    }
+}

--- a/crates/rpc/src/methods/group.rs
+++ b/crates/rpc/src/methods/group.rs
@@ -1,0 +1,31 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{GroupMembershipRow, GroupRow};
+
+/// Methods for group membership lookups.
+#[derive(Clone, Debug)]
+pub struct GroupMethods {
+    client: RpcClient,
+}
+
+impl GroupMethods {
+    /// Create a new accessor for group-related RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getGroupMemberships
+    pub async fn get_memberships(
+        &self,
+        avatar: circles_types::Address,
+    ) -> Result<Vec<GroupMembershipRow>> {
+        self.client
+            .call("circles_getGroupMemberships", (avatar,))
+            .await
+    }
+
+    /// circles_getGroups
+    pub async fn get_groups(&self, avatar: circles_types::Address) -> Result<Vec<GroupRow>> {
+        self.client.call("circles_getGroups", (avatar,)).await
+    }
+}

--- a/crates/rpc/src/methods/health.rs
+++ b/crates/rpc/src/methods/health.rs
@@ -1,0 +1,28 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use serde::Deserialize;
+
+/// Health payload returned by `circles_health`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct HealthResponse {
+    /// Human-friendly status string from the indexer.
+    pub status: String,
+}
+
+/// Methods for indexer health checks.
+#[derive(Clone, Debug)]
+pub struct HealthMethods {
+    client: RpcClient,
+}
+
+impl HealthMethods {
+    /// Create a new accessor for health RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_health
+    pub async fn health(&self) -> Result<HealthResponse> {
+        self.client.call("circles_health", ()).await
+    }
+}

--- a/crates/rpc/src/methods/invitation.rs
+++ b/crates/rpc/src/methods/invitation.rs
@@ -1,0 +1,63 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{Address, Balance};
+use futures::pin_mut;
+use futures::stream::{self, StreamExt};
+
+/// Methods for invitation discovery and balance lookups.
+#[derive(Clone, Debug)]
+pub struct InvitationMethods {
+    client: RpcClient,
+}
+
+/// Invitation + balance row returned by `get_invitations`.
+#[derive(Debug, serde::Deserialize)]
+pub struct InvitationRow {
+    /// The address that sent the invitation.
+    pub inviter: Address,
+    /// The invitee address queried.
+    pub invitee: Address,
+    /// Balance available for the invitee from this inviter.
+    pub invitation_balance: Balance,
+}
+
+impl InvitationMethods {
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getInvitations — batches balance lookups concurrently per invitee.
+    pub async fn get_invitations(&self, invitee: Address) -> Result<Vec<InvitationRow>> {
+        // Fetch inviters list first.
+        let inviters: Vec<Address> = self
+            .client
+            .call("circles_getInvitations", (invitee,))
+            .await?;
+
+        // Concurrently fetch balances with bounded concurrency to avoid hammering the RPC.
+        const MAX_CONCURRENT: usize = 10;
+        let client = self.client.clone();
+        let invitee_addr = invitee;
+        let stream = stream::iter(inviters.into_iter().map(move |inviter| {
+            let client = client.clone();
+            async move {
+                let bal: Balance = client
+                    .call("circles_getInvitationBalance", (inviter, invitee_addr))
+                    .await?;
+                Ok::<_, crate::error::CirclesRpcError>(InvitationRow {
+                    inviter,
+                    invitee: invitee_addr,
+                    invitation_balance: bal,
+                })
+            }
+        }))
+        .buffer_unordered(MAX_CONCURRENT);
+
+        let mut rows = Vec::new();
+        pin_mut!(stream);
+        while let Some(res) = stream.next().await {
+            rows.push(res?);
+        }
+        Ok(rows)
+    }
+}

--- a/crates/rpc/src/methods/mod.rs
+++ b/crates/rpc/src/methods/mod.rs
@@ -1,0 +1,32 @@
+//! RPC method namespaces. Each module mirrors the TS SDK methods with
+//! thin wrappers around `RpcClient`.
+
+pub mod avatar;
+pub mod balance;
+pub mod events;
+pub mod group;
+pub mod health;
+pub mod invitation;
+pub mod network;
+pub mod pathfinder;
+pub mod query;
+pub mod search;
+pub mod tables;
+pub mod token;
+pub mod token_info;
+pub mod trust;
+
+pub use avatar::AvatarMethods;
+pub use balance::BalanceMethods;
+pub use events::EventsMethods;
+pub use group::GroupMethods;
+pub use health::HealthMethods;
+pub use invitation::InvitationMethods;
+pub use network::NetworkMethods;
+pub use pathfinder::PathfinderMethods;
+pub use query::QueryMethods;
+pub use search::SearchMethods;
+pub use tables::TablesMethods;
+pub use token::TokenMethods;
+pub use token_info::TokenInfoMethods;
+pub use trust::TrustMethods;

--- a/crates/rpc/src/methods/network.rs
+++ b/crates/rpc/src/methods/network.rs
@@ -1,0 +1,21 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::NetworkSnapshot;
+
+/// Methods for fetching network snapshots.
+#[derive(Clone, Debug)]
+pub struct NetworkMethods {
+    client: RpcClient,
+}
+
+impl NetworkMethods {
+    /// Create a new accessor for network snapshot RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getNetworkSnapshot
+    pub async fn snapshot(&self) -> Result<NetworkSnapshot> {
+        self.client.call("circles_getNetworkSnapshot", ()).await
+    }
+}

--- a/crates/rpc/src/methods/pathfinder.rs
+++ b/crates/rpc/src/methods/pathfinder.rs
@@ -35,7 +35,7 @@ impl PathfinderMethods {
         }
         let payload = Payload {
             params,
-            simulated_balances: simulated_balances,
+            simulated_balances,
         };
         self.client.call("circlesV2_findPath", (payload,)).await
     }

--- a/crates/rpc/src/methods/pathfinder.rs
+++ b/crates/rpc/src/methods/pathfinder.rs
@@ -1,0 +1,42 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{FindPathParams, PathfindingResult, SimulatedBalance};
+use serde::Serialize;
+
+/// Methods for invoking the pathfinder (max-flow) RPC.
+#[derive(Clone, Debug)]
+pub struct PathfinderMethods {
+    client: RpcClient,
+}
+
+impl PathfinderMethods {
+    /// Create a new accessor for pathfinder RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circlesV2_findPath — accepts full FindPathParams
+    pub async fn find_path(&self, params: FindPathParams) -> Result<PathfindingResult> {
+        self.client.call("circlesV2_findPath", (params,)).await
+    }
+
+    /// Token swap variant: uses the same RPC but allows specifying tokens/simulated balances.
+    pub async fn find_path_with_simulation(
+        &self,
+        params: FindPathParams,
+        simulated_balances: Option<Vec<SimulatedBalance>>,
+    ) -> Result<PathfindingResult> {
+        #[derive(Debug, Clone, Serialize)]
+        struct Payload {
+            #[serde(flatten)]
+            params: FindPathParams,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            simulated_balances: Option<Vec<SimulatedBalance>>,
+        }
+        let payload = Payload {
+            params,
+            simulated_balances: simulated_balances,
+        };
+        self.client.call("circlesV2_findPath", (payload,)).await
+    }
+}

--- a/crates/rpc/src/methods/query.rs
+++ b/crates/rpc/src/methods/query.rs
@@ -1,0 +1,171 @@
+use crate::client::RpcClient;
+use crate::error::{CirclesRpcError, Result};
+use circles_types::{CirclesQueryResponse, OrderBy, PagedQueryParams, PagedResult, QueryParams};
+use serde_json::Value;
+
+/// Methods for issuing `circles_query` requests and decoding the tabular response.
+#[derive(Clone, Debug)]
+pub struct QueryMethods {
+    client: RpcClient,
+}
+
+impl QueryMethods {
+    /// Create a new accessor for `circles_query` RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// Direct `circles_query` invocation returning decoded rows.
+    pub async fn circles_query<TRow>(&self, params: QueryParams) -> Result<Vec<TRow>>
+    where
+        TRow: serde::de::DeserializeOwned + Send + Sync + std::fmt::Debug + Unpin + 'static,
+    {
+        let result: CirclesQueryResponse = self.client.call("circles_query", (params,)).await?;
+        self.decode_rows::<TRow>(result.columns, result.rows)
+    }
+
+    /// Convenience wrapper for paged queries using the `circles_query` method.
+    /// Note: The underlying backend expects `QueryParams`; we translate from the
+    /// higher-level `PagedQueryParams` struct.
+    pub async fn paged_query<TRow>(&self, params: PagedQueryParams) -> Result<PagedResult<TRow>>
+    where
+        TRow: serde::de::DeserializeOwned
+            + serde::Serialize
+            + Clone
+            + Send
+            + Sync
+            + std::fmt::Debug
+            + Unpin
+            + 'static,
+    {
+        let PagedQueryParams {
+            namespace,
+            table,
+            sort_order,
+            columns,
+            filter,
+            limit,
+        } = params.clone();
+
+        // Convert to QueryParams. If the caller supplied an order, we would add it here; for now
+        // we ensure stable ordering via block/tx/log and timestamp.
+        let mut order: Vec<OrderBy> = Vec::new();
+        let dir = sort_order.clone();
+        order.push(OrderBy::new("blockNumber".to_string(), dir.clone()));
+        order.push(OrderBy::new("transactionIndex".to_string(), dir.clone()));
+        order.push(OrderBy::new("logIndex".to_string(), dir.clone()));
+        order.push(OrderBy::new("timestamp".to_string(), dir));
+
+        let query_params = QueryParams {
+            namespace,
+            table,
+            columns,
+            filter: filter.unwrap_or_default(),
+            order,
+            limit: Some(limit),
+        };
+
+        let result: CirclesQueryResponse =
+            self.client.call("circles_query", (query_params,)).await?;
+
+        let rows = self.decode_rows::<TRow>(result.columns.clone(), result.rows.clone())?;
+        let cursors = self.extract_cursors(&result.columns, &result.rows);
+        let first_cursor = cursors.first().cloned();
+        let last_cursor = cursors.last().cloned();
+        let size = rows.len() as u32;
+        let has_more = size == limit;
+
+        Ok(PagedResult {
+            limit,
+            size,
+            first_cursor,
+            last_cursor,
+            sort_order,
+            has_more,
+            results: rows,
+        })
+    }
+
+    pub fn decode_rows<TRow>(
+        &self,
+        columns: Vec<String>,
+        rows: Vec<Vec<Value>>,
+    ) -> Result<Vec<TRow>>
+    where
+        TRow: serde::de::DeserializeOwned,
+    {
+        rows.into_iter()
+            .map(|row| self.decode_row::<TRow>(&columns, row))
+            .collect()
+    }
+
+    pub fn decode_row<TRow>(&self, columns: &[String], row: Vec<Value>) -> Result<TRow>
+    where
+        TRow: serde::de::DeserializeOwned,
+    {
+        if columns.len() != row.len() {
+            return Err(CirclesRpcError::InvalidResponse {
+                message: "circles_query row length mismatch".to_string(),
+            });
+        }
+        let mut map = serde_json::Map::new();
+        for (col, val) in columns.iter().cloned().zip(row.into_iter()) {
+            map.insert(col, val);
+        }
+        serde_json::from_value(Value::Object(map)).map_err(|e| CirclesRpcError::InvalidResponse {
+            message: e.to_string(),
+        })
+    }
+
+    pub fn extract_cursors(
+        &self,
+        columns: &[String],
+        rows: &[Vec<Value>],
+    ) -> Vec<circles_types::Cursor> {
+        rows.iter()
+            .filter_map(|row| self.extract_cursor(columns, row))
+            .collect()
+    }
+
+    fn extract_cursor(&self, columns: &[String], row: &[Value]) -> Option<circles_types::Cursor> {
+        let mut block_number: Option<u64> = None;
+        let mut tx_index: Option<u32> = None;
+        let mut log_index: Option<u32> = None;
+        let mut batch_index: Option<u32> = None;
+        let mut timestamp: Option<u64> = None;
+
+        for (col, val) in columns.iter().zip(row.iter()) {
+            match col.as_str() {
+                "blockNumber" => block_number = Self::as_u64(val),
+                "transactionIndex" => tx_index = Self::as_u32(val),
+                "logIndex" => log_index = Self::as_u32(val),
+                "batchIndex" => batch_index = Self::as_u32(val),
+                "timestamp" => timestamp = Self::as_u64(val),
+                _ => {}
+            }
+        }
+
+        match (block_number, tx_index, log_index) {
+            (Some(b), Some(tx), Some(log)) => Some(circles_types::Cursor {
+                block_number: b,
+                transaction_index: tx,
+                log_index: log,
+                batch_index,
+                timestamp,
+            }),
+            _ => None,
+        }
+    }
+
+    fn as_u64(val: &Value) -> Option<u64> {
+        match val {
+            Value::Number(n) => n.as_u64(),
+            Value::String(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+
+    fn as_u32(val: &Value) -> Option<u32> {
+        Self::as_u64(val).map(|v| v as u32)
+    }
+}

--- a/crates/rpc/src/methods/search.rs
+++ b/crates/rpc/src/methods/search.rs
@@ -1,0 +1,23 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::Profile;
+
+/// Methods for full-text profile search.
+#[derive(Clone, Debug)]
+pub struct SearchMethods {
+    client: RpcClient,
+}
+
+impl SearchMethods {
+    /// Create a new accessor for search RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_searchProfiles
+    pub async fn search_profiles(&self, query: String, limit: Option<u32>) -> Result<Vec<Profile>> {
+        self.client
+            .call("circles_searchProfiles", (query, limit))
+            .await
+    }
+}

--- a/crates/rpc/src/methods/tables.rs
+++ b/crates/rpc/src/methods/tables.rs
@@ -1,0 +1,21 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::TableInfo;
+
+/// Methods for table/schema introspection.
+#[derive(Clone, Debug)]
+pub struct TablesMethods {
+    client: RpcClient,
+}
+
+impl TablesMethods {
+    /// Create a new accessor for table listing RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_tables
+    pub async fn tables(&self) -> Result<Vec<TableInfo>> {
+        self.client.call("circles_tables", ()).await
+    }
+}

--- a/crates/rpc/src/methods/token.rs
+++ b/crates/rpc/src/methods/token.rs
@@ -1,0 +1,72 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use alloy_primitives::U256;
+use circles_types::{Address, TokenBalanceResponse, TokenHolder};
+use std::str::FromStr;
+
+/// Methods for token balance and holder lookups.
+#[derive(Clone, Debug)]
+pub struct TokenMethods {
+    client: RpcClient,
+}
+
+/// Normalized token holder with numeric balance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenHolderNormalized {
+    /// Account that owns the token balance.
+    pub account: Address,
+    /// The token address.
+    pub token_address: Address,
+    /// Balance as `U256` (demurraged).
+    pub balance: U256,
+}
+
+impl From<TokenHolder> for TokenHolderNormalized {
+    fn from(holder: TokenHolder) -> Self {
+        let balance = U256::from_str(&holder.demurraged_total_balance).unwrap_or_default();
+        Self {
+            account: holder.account,
+            token_address: holder.token_address,
+            balance,
+        }
+    }
+}
+
+impl TokenMethods {
+    /// Create a new accessor for token-related RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getTokenBalances (v1/v2, selected via `use_v2`)
+    pub async fn get_token_balances(
+        &self,
+        address: Address,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>> {
+        let method = if use_v2 {
+            "circlesV2_getTokenBalances"
+        } else {
+            "circles_getTokenBalances"
+        };
+        self.client.call(method, (address, as_time_circles)).await
+    }
+
+    /// circles_getTokenHolders (currently assumed v2) returning normalized balances by default.
+    pub async fn get_token_holders(&self, token: Address) -> Result<Vec<TokenHolderNormalized>> {
+        let holders: Vec<TokenHolder> = self
+            .client
+            .call("circles_getTokenHolders", (token,))
+            .await?;
+        Ok(holders
+            .into_iter()
+            .map(TokenHolderNormalized::from)
+            .collect())
+    }
+
+    /// Raw token holders (string balances) if needed.
+    pub async fn get_token_holders_raw(&self, token: Address) -> Result<Vec<TokenHolder>> {
+        self.client.call("circles_getTokenHolders", (token,)).await
+    }
+}

--- a/crates/rpc/src/methods/token_info.rs
+++ b/crates/rpc/src/methods/token_info.rs
@@ -1,0 +1,28 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{Address, TokenInfo};
+
+/// Methods for retrieving token metadata.
+#[derive(Clone, Debug)]
+pub struct TokenInfoMethods {
+    client: RpcClient,
+}
+
+impl TokenInfoMethods {
+    /// Create a new accessor for token metadata RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getTokenInfo
+    pub async fn get_token_info(&self, token: Address) -> Result<TokenInfo> {
+        self.client.call("circles_getTokenInfo", (token,)).await
+    }
+
+    /// circles_getTokenInfoBatch
+    pub async fn get_token_info_batch(&self, tokens: Vec<Address>) -> Result<Vec<TokenInfo>> {
+        self.client
+            .call("circles_getTokenInfoBatch", (tokens,))
+            .await
+    }
+}

--- a/crates/rpc/src/methods/trust.rs
+++ b/crates/rpc/src/methods/trust.rs
@@ -1,0 +1,34 @@
+use crate::client::RpcClient;
+use crate::error::Result;
+use circles_types::{Address, TrustRelation, TrustRelationType};
+
+/// Methods for trust relation queries.
+#[derive(Clone, Debug)]
+pub struct TrustMethods {
+    client: RpcClient,
+}
+
+impl TrustMethods {
+    /// Create a new accessor for trust-related RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// circles_getTrustRelations
+    pub async fn get_trust_relations(&self, address: Address) -> Result<Vec<TrustRelation>> {
+        self.client
+            .call("circles_getTrustRelations", (address,))
+            .await
+    }
+
+    /// circles_getCommonTrust
+    pub async fn get_common_trust(
+        &self,
+        avatar_a: Address,
+        avatar_b: Address,
+    ) -> Result<Vec<TrustRelationType>> {
+        self.client
+            .call("circles_getCommonTrust", (avatar_a, avatar_b))
+            .await
+    }
+}

--- a/crates/rpc/src/paged_query.rs
+++ b/crates/rpc/src/paged_query.rs
@@ -1,0 +1,125 @@
+use crate::error::Result;
+use circles_types::{
+    Cursor, Filter, FilterPredicate, FilterType, PagedQueryParams, PagedResult, SortOrder,
+};
+use futures::{Stream, StreamExt};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Represents a page of results returned by [`PagedQuery`].
+#[derive(Debug, Clone)]
+pub struct Page<T> {
+    /// Items contained in this page.
+    pub items: Vec<T>,
+    /// Cursor pointing to the first row.
+    pub first_cursor: Option<Cursor>,
+    /// Cursor pointing to the last row.
+    pub last_cursor: Option<Cursor>,
+    /// Whether more results are available after this page.
+    pub has_more: bool,
+}
+
+pub type PagedFetch<TRow> = Arc<
+    dyn Fn(PagedQueryParams) -> Pin<Box<dyn Future<Output = Result<PagedResult<TRow>>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Generic paginator that wraps the `circles_query` RPC method.
+/// The fetcher function is responsible for honoring `current_cursor` if desired.
+// TODO: table-aware default ordering + helper to apply cursor to params.
+pub struct PagedQuery<TRow: Clone + Serialize> {
+    fetch: PagedFetch<TRow>,
+    /// Base params to reuse across calls.
+    pub params: PagedQueryParams,
+    /// Last cursor that was seen (advanced after each page).
+    pub current_cursor: Option<Cursor>,
+}
+
+impl<TRow> PagedQuery<TRow>
+where
+    TRow: Clone + Serialize + DeserializeOwned + Send + 'static,
+{
+    pub fn new(fetch: PagedFetch<TRow>, params: PagedQueryParams) -> Self {
+        Self {
+            fetch,
+            params,
+            current_cursor: None,
+        }
+    }
+
+    /// Fetch the next page. Consumers can track `current_cursor` to drive cursor-based filters.
+    pub async fn next_page(&mut self) -> Result<Option<Page<TRow>>> {
+        let mut params = self.params.clone();
+
+        // Inject cursor filters if a cursor is present.
+        if let Some(cursor) = &self.current_cursor {
+            let cmp = match params.sort_order {
+                SortOrder::ASC => FilterType::GreaterOrEqualThan,
+                SortOrder::DESC => FilterType::LessOrEqualThan,
+            };
+            let mut filters: Vec<Filter> = params.filter.unwrap_or_default();
+            filters.push(
+                FilterPredicate::new(cmp.clone(), "blockNumber".to_string(), cursor.block_number)
+                    .into(),
+            );
+            filters.push(
+                FilterPredicate::new(
+                    cmp.clone(),
+                    "transactionIndex".to_string(),
+                    cursor.transaction_index,
+                )
+                .into(),
+            );
+            filters.push(
+                FilterPredicate::new(cmp.clone(), "logIndex".to_string(), cursor.log_index).into(),
+            );
+            if let Some(batch) = cursor.batch_index {
+                filters.push(FilterPredicate::new(cmp, "batchIndex".to_string(), batch).into());
+            }
+            params.filter = Some(filters);
+        }
+
+        let result = (self.fetch)(params).await?;
+
+        if result.results.is_empty() {
+            return Ok(None);
+        }
+
+        // Advance cursor to the last item returned.
+        self.current_cursor = result.last_cursor.clone();
+
+        Ok(Some(Page {
+            items: result.results,
+            first_cursor: result.first_cursor,
+            last_cursor: result.last_cursor,
+            has_more: result.has_more,
+        }))
+    }
+
+    /// Convert this paginator into a stream of rows.
+    pub fn into_stream(self) -> impl Stream<Item = Result<TRow>> {
+        futures::stream::unfold(self, |mut state| async move {
+            match state.next_page().await {
+                Ok(Some(page)) => {
+                    let has_more = page.has_more;
+                    let items = page.items;
+                    if has_more {
+                        Some((Ok(items), state))
+                    } else {
+                        None
+                    }
+                }
+                Ok(None) => None,
+                Err(e) => Some((Err(e), state)),
+            }
+        })
+        .flat_map(|res| match res {
+            Ok(vec) => futures::stream::iter(vec.into_iter().map(Ok)).boxed(),
+            Err(err) => futures::stream::iter(vec![Err(err)]).boxed(),
+        })
+    }
+}

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -1,0 +1,184 @@
+use crate::client::RpcClient;
+use crate::error::{CirclesRpcError, Result};
+use crate::methods::{
+    AvatarMethods, BalanceMethods, EventsMethods, GroupMethods, HealthMethods, InvitationMethods,
+    NetworkMethods, PathfinderMethods, QueryMethods, SearchMethods, TablesMethods,
+    TokenInfoMethods, TokenMethods, TrustMethods,
+};
+use crate::paged_query::{PagedFetch, PagedQuery};
+use circles_types::PagedQueryParams;
+use futures::Stream;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// High-level facade that mirrors the TypeScript SDK entry point.
+///
+/// This type exposes grouped method accessors and convenience helpers for pagination
+/// and streaming. It can be built from an HTTP URL or any pre-built [`RpcClient`].
+pub struct CirclesRpc {
+    pub client: RpcClient,
+}
+
+impl CirclesRpc {
+    /// Construct from a pre-built client (useful for dependency injection in tests).
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// Build from an HTTP endpoint URL.
+    pub fn from_http_url(url: reqwest::Url) -> Self {
+        Self {
+            client: RpcClient::http(url),
+        }
+    }
+
+    /// Build from a WebSocket endpoint URL (requires the `ws` feature).
+    #[cfg(feature = "ws")]
+    pub async fn from_ws_url(url: reqwest::Url) -> Result<Self> {
+        Ok(Self {
+            client: RpcClient::ws(url).await?,
+        })
+    }
+
+    /// Convenience helper to parse `&str` URLs into [`CirclesRpc`].
+    pub fn try_from_http(url: &str) -> Result<Self> {
+        let parsed = url
+            .parse::<reqwest::Url>()
+            .map_err(|e| CirclesRpcError::InvalidResponse {
+                message: e.to_string(),
+            })?;
+        Ok(Self::from_http_url(parsed))
+    }
+
+    /// Convenience helper to parse `&str` WS URLs into [`CirclesRpc`] (requires `ws` feature).
+    #[cfg(feature = "ws")]
+    pub async fn try_from_ws(url: &str) -> Result<Self> {
+        let parsed = url
+            .parse::<reqwest::Url>()
+            .map_err(|e| CirclesRpcError::InvalidResponse {
+                message: e.to_string(),
+            })?;
+        Self::from_ws_url(parsed).await
+    }
+
+    // Method accessors
+    /// RPC methods that return aggregate balances.
+    pub fn balance(&self) -> BalanceMethods {
+        BalanceMethods::new(self.client.clone())
+    }
+    /// RPC methods for token holder/balance queries.
+    pub fn token(&self) -> TokenMethods {
+        TokenMethods::new(self.client.clone())
+    }
+    /// RPC methods returning token metadata.
+    pub fn token_info(&self) -> TokenInfoMethods {
+        TokenInfoMethods::new(self.client.clone())
+    }
+    /// RPC methods for trust relations.
+    pub fn trust(&self) -> TrustMethods {
+        TrustMethods::new(self.client.clone())
+    }
+    /// RPC methods for avatar/profile lookup.
+    pub fn avatar(&self) -> AvatarMethods {
+        AvatarMethods::new(self.client.clone())
+    }
+    /// Low-level `circles_query` table accessors and pagination helpers.
+    pub fn query(&self) -> QueryMethods {
+        QueryMethods::new(self.client.clone())
+    }
+    /// RPC methods for fetching events over HTTP or websocket.
+    pub fn events(&self) -> EventsMethods {
+        EventsMethods::new(self.client.clone())
+    }
+    /// RPC methods for invitations with internal batching.
+    pub fn invitation(&self) -> InvitationMethods {
+        InvitationMethods::new(self.client.clone())
+    }
+    /// RPC methods for path-finding in the trust graph.
+    pub fn pathfinder(&self) -> PathfinderMethods {
+        PathfinderMethods::new(self.client.clone())
+    }
+    /// RPC methods for group lookups.
+    pub fn group(&self) -> GroupMethods {
+        GroupMethods::new(self.client.clone())
+    }
+    /// RPC methods for querying database tables/introspection.
+    pub fn tables(&self) -> TablesMethods {
+        TablesMethods::new(self.client.clone())
+    }
+    /// RPC methods for indexer health checks.
+    pub fn health(&self) -> HealthMethods {
+        HealthMethods::new(self.client.clone())
+    }
+    /// RPC methods for network snapshots.
+    pub fn network(&self) -> NetworkMethods {
+        NetworkMethods::new(self.client.clone())
+    }
+    /// RPC methods for profile search.
+    pub fn search(&self) -> SearchMethods {
+        SearchMethods::new(self.client.clone())
+    }
+
+    /// Build a `PagedQuery` helper around `circles_query`.
+    pub fn paged_query<TRow>(&self, params: PagedQueryParams) -> PagedQuery<TRow>
+    where
+        TRow: serde::de::DeserializeOwned
+            + serde::Serialize
+            + Clone
+            + Send
+            + Sync
+            + std::fmt::Debug
+            + Unpin
+            + 'static,
+    {
+        let client = self.client.clone();
+        let fetch: PagedFetch<TRow> = Arc::new(move |params: PagedQueryParams| {
+            let client = client.clone();
+            Box::pin(async move {
+                // Use the higher-level query helper to decode rows and cursors.
+                QueryMethods::new(client).paged_query::<TRow>(params).await
+            })
+                as Pin<
+                    Box<
+                        dyn std::future::Future<Output = Result<circles_types::PagedResult<TRow>>>
+                            + Send,
+                    >,
+                >
+        });
+        PagedQuery::new(fetch, params)
+    }
+
+    /// Convenience: directly get a stream of rows for a paged query.
+    pub fn paged_stream<TRow>(&self, params: PagedQueryParams) -> impl Stream<Item = Result<TRow>>
+    where
+        TRow: serde::de::DeserializeOwned
+            + serde::Serialize
+            + Clone
+            + Send
+            + Sync
+            + std::fmt::Debug
+            + Unpin
+            + 'static,
+    {
+        self.paged_query(params).into_stream()
+    }
+}
+
+impl From<reqwest::Url> for CirclesRpc {
+    fn from(url: reqwest::Url) -> Self {
+        Self::from_http_url(url)
+    }
+}
+
+impl TryFrom<&str> for CirclesRpc {
+    type Error = CirclesRpcError;
+
+    fn try_from(value: &str) -> Result<Self> {
+        let url = value
+            .parse::<reqwest::Url>()
+            .map_err(|e| CirclesRpcError::InvalidResponse {
+                message: e.to_string(),
+            })?;
+        Ok(Self::from_http_url(url))
+    }
+}

--- a/crates/rpc/src/utils.rs
+++ b/crates/rpc/src/utils.rs
@@ -1,0 +1,49 @@
+//! Shared helpers for address normalization and conversions.
+
+use alloy_primitives::Address;
+use circles_types::{Cursor, EventRow};
+
+/// Ensure addresses are consistently checksummed.
+pub fn normalize_address(addr: Address) -> Address {
+    addr
+}
+
+/// Build a cursor filter tuple (column, value) based on the provided cursor.
+pub fn cursor_filters(cursor: &Cursor, sort_desc: bool) -> Vec<(String, serde_json::Value)> {
+    let op = if sort_desc { "<=" } else { ">=" };
+    vec![
+        (
+            format!("blockNumber {op}"),
+            serde_json::json!(cursor.block_number),
+        ),
+        (
+            format!("transactionIndex {op}"),
+            serde_json::json!(cursor.transaction_index),
+        ),
+        (
+            format!("logIndex {op}"),
+            serde_json::json!(cursor.log_index),
+        ),
+    ]
+}
+
+/// Extract cursors from rows when the row type includes the base event fields.
+pub fn extract_cursor(row: &impl CursorLike) -> Cursor {
+    row.to_cursor()
+}
+
+pub trait CursorLike {
+    fn to_cursor(&self) -> Cursor;
+}
+
+impl CursorLike for EventRow {
+    fn to_cursor(&self) -> Cursor {
+        Cursor {
+            block_number: self.block_number,
+            transaction_index: self.transaction_index,
+            log_index: self.log_index,
+            batch_index: self.batch_index,
+            timestamp: self.timestamp,
+        }
+    }
+}

--- a/crates/rpc/tests/common_trust_decode.rs
+++ b/crates/rpc/tests/common_trust_decode.rs
@@ -1,0 +1,12 @@
+use circles_types::TrustRelationType;
+
+#[test]
+fn decode_common_trust() {
+    let rels: Vec<TrustRelationType> =
+        serde_json::from_str(include_str!("fixtures/common_trust.json"))
+            .expect("parse common trust");
+    assert_eq!(
+        rels,
+        vec![TrustRelationType::Trusts, TrustRelationType::MutuallyTrusts]
+    );
+}

--- a/crates/rpc/tests/events_http_decode.rs
+++ b/crates/rpc/tests/events_http_decode.rs
@@ -1,0 +1,22 @@
+use circles_rpc::events::parser::parse;
+use circles_types::{CirclesEvent, RpcSubscriptionEvent};
+
+#[test]
+fn decode_http_circles_events() {
+    let raw: Vec<RpcSubscriptionEvent> =
+        serde_json::from_str(include_str!("fixtures/circles_events_http.json"))
+            .expect("parse circles_events payload");
+    assert_eq!(raw.len(), 2);
+
+    let parsed: Vec<CirclesEvent> = raw.into_iter().map(|e| parse(e).unwrap()).collect();
+    assert_eq!(
+        parsed[0].event_type,
+        circles_types::CirclesEventType::CrcV2RegisterHuman
+    );
+    assert_eq!(parsed[0].base.block_number, 30000000);
+    assert_eq!(
+        parsed[1].event_type,
+        circles_types::CirclesEventType::CrcV2Trust
+    );
+    assert_eq!(parsed[1].base.log_index, 5);
+}

--- a/crates/rpc/tests/events_parse.rs
+++ b/crates/rpc/tests/events_parse.rs
@@ -1,0 +1,14 @@
+use circles_rpc::events::parser::parse;
+use circles_types::{CirclesEvent, RpcSubscriptionEvent};
+
+#[test]
+fn parse_rpc_subscription_event_into_circles_event() {
+    let raw: RpcSubscriptionEvent =
+        serde_json::from_str(include_str!("fixtures/circles_events.json")).unwrap();
+    let parsed: CirclesEvent = parse(raw).expect("parse event");
+    assert_eq!(format!("{:?}", parsed.event_type), "CrcV2RegisterHuman");
+    assert_eq!(parsed.base.block_number, 30000000);
+    assert_eq!(parsed.base.transaction_index, 1);
+    assert_eq!(parsed.base.log_index, 0);
+    assert_eq!(parsed.base.timestamp, Some(1710000000));
+}

--- a/crates/rpc/tests/fixtures/circles_events.json
+++ b/crates/rpc/tests/fixtures/circles_events.json
@@ -1,0 +1,10 @@
+{
+  "event": "CrcV2RegisterHuman",
+  "values": {
+    "avatar": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "blockNumber": 30000000,
+    "transactionIndex": 1,
+    "logIndex": 0,
+    "timestamp": 1710000000
+  }
+}

--- a/crates/rpc/tests/fixtures/circles_events_http.json
+++ b/crates/rpc/tests/fixtures/circles_events_http.json
@@ -1,0 +1,24 @@
+[
+  {
+    "event": "CrcV2RegisterHuman",
+    "values": {
+      "avatar": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+      "blockNumber": 30000000,
+      "transactionIndex": 1,
+      "logIndex": 0,
+      "timestamp": 1710000000
+    }
+  },
+  {
+    "event": "CrcV2_Trust",
+    "values": {
+      "truster": "0xfeed00000000000000000000000000000000beef",
+      "trustee": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+      "expiryTime": "1800000000",
+      "blockNumber": 30000001,
+      "transactionIndex": 2,
+      "logIndex": 5,
+      "timestamp": 1710000100
+    }
+  }
+]

--- a/crates/rpc/tests/fixtures/circles_query_batch.json
+++ b/crates/rpc/tests/fixtures/circles_query_batch.json
@@ -1,0 +1,6 @@
+{
+  "Columns": ["blockNumber", "transactionIndex", "logIndex", "batchIndex", "timestamp", "operator", "from", "to"],
+  "Rows": [
+    [40000000, 2, 7, 3, 1715000000, "0xaaa0000000000000000000000000000000000000", "0xbbb0000000000000000000000000000000000000", "0xccc0000000000000000000000000000000000000"]
+  ]
+}

--- a/crates/rpc/tests/fixtures/circles_query_response.json
+++ b/crates/rpc/tests/fixtures/circles_query_response.json
@@ -1,0 +1,7 @@
+{
+  "Columns": ["blockNumber", "transactionIndex", "logIndex", "timestamp", "avatar", "version"],
+  "Rows": [
+    [30000000, 1, 0, 1710000000, "0xde374ece6fa50e781e81aac78e811b33d16912c7", 2],
+    [29999999, 3, 5, 1709999990, "0xfeed00000000000000000000000000000000beef", 2]
+  ]
+}

--- a/crates/rpc/tests/fixtures/common_trust.json
+++ b/crates/rpc/tests/fixtures/common_trust.json
@@ -1,0 +1,4 @@
+[
+  "trusts",
+  "mutuallyTrusts"
+]

--- a/crates/rpc/tests/fixtures/profile_batch.json
+++ b/crates/rpc/tests/fixtures/profile_batch.json
@@ -1,0 +1,14 @@
+[
+  {
+    "avatar": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "name": "Alice",
+    "description": "Test user",
+    "image": "ipfs://cid1"
+  },
+  {
+    "avatar": "0xfeed00000000000000000000000000000000beef",
+    "name": "Bob",
+    "description": "Another user",
+    "image": "ipfs://cid2"
+  }
+]

--- a/crates/rpc/tests/fixtures/token_balances.json
+++ b/crates/rpc/tests/fixtures/token_balances.json
@@ -1,0 +1,12 @@
+[
+  {
+    "token_id": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "balance": "0x1234",
+    "token_owner": "0xde374ece6fa50e781e81aac78e811b33d16912c7"
+  },
+  {
+    "token_id": "0xfeed00000000000000000000000000000000beef",
+    "balance": 100000,
+    "token_owner": "0xde374ece6fa50e781e81aac78e811b33d16912c7"
+  }
+]

--- a/crates/rpc/tests/fixtures/token_holders.json
+++ b/crates/rpc/tests/fixtures/token_holders.json
@@ -1,0 +1,12 @@
+[
+  {
+    "account": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "token_address": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "demurraged_total_balance": "12345678901234567890"
+  },
+  {
+    "account": "0xfeed00000000000000000000000000000000beef",
+    "token_address": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "demurraged_total_balance": "0"
+  }
+]

--- a/crates/rpc/tests/fixtures/trust_relations.json
+++ b/crates/rpc/tests/fixtures/trust_relations.json
@@ -1,0 +1,12 @@
+[
+  {
+    "block_number": 40000001,
+    "timestamp": 1716000000,
+    "transaction_index": 2,
+    "log_index": 4,
+    "transaction_hash": "0xaaa0000000000000000000000000000000000000000000000000000000000001",
+    "truster": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "trustee": "0xfeed00000000000000000000000000000000beef",
+    "expiry_time": 1800000000
+  }
+]

--- a/crates/rpc/tests/profile_decode.rs
+++ b/crates/rpc/tests/profile_decode.rs
@@ -1,0 +1,10 @@
+use circles_types::Profile;
+
+#[test]
+fn decode_profile_batch() {
+    let profiles: Vec<Profile> =
+        serde_json::from_str(include_str!("fixtures/profile_batch.json")).expect("parse profiles");
+    assert_eq!(profiles.len(), 2);
+    assert_eq!(profiles[0].name, "Alice");
+    assert_eq!(profiles[1].name, "Bob");
+}

--- a/crates/rpc/tests/query_decode.rs
+++ b/crates/rpc/tests/query_decode.rs
@@ -1,0 +1,104 @@
+use circles_rpc::RpcClient;
+use circles_rpc::methods::QueryMethods;
+use circles_types::{PagedQueryParams, SortOrder};
+use serde_json::{Value, json};
+
+// Helper: construct a QueryMethods with a dummy RpcClient; we only use its decode helpers.
+fn query_methods() -> QueryMethods {
+    QueryMethods::new(RpcClient::http("http://localhost".parse().unwrap()))
+}
+
+#[test]
+fn decode_circles_query_rows() {
+    let raw: Value =
+        serde_json::from_str(include_str!("fixtures/circles_query_response.json")).unwrap();
+    let columns: Vec<String> = raw["Columns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    let rows: Vec<Vec<Value>> = raw["Rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row.as_array().unwrap().to_vec())
+        .collect();
+
+    let methods = query_methods();
+    let decoded: Vec<Value> = methods.decode_rows(columns.clone(), rows.clone()).unwrap();
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(
+        decoded[0]["avatar"],
+        json!("0xde374ece6fa50e781e81aac78e811b33d16912c7")
+    );
+
+    // Ensure cursors extract correctly.
+    let cursors = methods.extract_cursors(&columns, &rows);
+    assert_eq!(cursors.len(), 2);
+    assert_eq!(cursors[0].block_number, 30000000);
+    assert_eq!(cursors[0].transaction_index, 1);
+    assert_eq!(cursors[0].log_index, 0);
+    assert_eq!(cursors[0].timestamp, Some(1710000000));
+}
+
+#[test]
+fn paged_query_has_more_logic() {
+    // Simulate rows equal to limit to check cursor extraction; has_more calculation is implicit when size == limit.
+    let methods = query_methods();
+    let columns = vec![
+        "blockNumber".to_string(),
+        "transactionIndex".to_string(),
+        "logIndex".to_string(),
+        "timestamp".to_string(),
+        "avatar".to_string(),
+    ];
+    let rows = vec![
+        vec![json!(10), json!(0), json!(0), json!(1700), json!("0x1")],
+        vec![json!(9), json!(1), json!(0), json!(1699), json!("0x2")],
+    ];
+    let cursors = methods.extract_cursors(&columns, &rows);
+    assert_eq!(cursors.len(), 2);
+    assert_eq!(cursors[1].timestamp, Some(1699));
+
+    let params = PagedQueryParams {
+        namespace: "V_Crc".to_string(),
+        table: "Avatars".to_string(),
+        sort_order: SortOrder::DESC,
+        columns: vec!["avatar".to_string()],
+        filter: None,
+        limit: 2,
+    };
+
+    // Build a fake CirclesQueryResponse-like payload and reuse decode_rows to simulate paged_query output.
+    let decoded: Vec<Value> = methods.decode_rows(columns.clone(), rows.clone()).unwrap();
+    assert_eq!(decoded.len(), params.limit as usize);
+}
+
+#[test]
+fn extract_cursor_with_batch_index() {
+    let raw: Value =
+        serde_json::from_str(include_str!("fixtures/circles_query_batch.json")).unwrap();
+    let columns: Vec<String> = raw["Columns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    let rows: Vec<Vec<Value>> = raw["Rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row.as_array().unwrap().to_vec())
+        .collect();
+
+    let methods = query_methods();
+    let cursors = methods.extract_cursors(&columns, &rows);
+    assert_eq!(cursors.len(), 1);
+    let cursor = &cursors[0];
+    assert_eq!(cursor.block_number, 40000000);
+    assert_eq!(cursor.transaction_index, 2);
+    assert_eq!(cursor.log_index, 7);
+    assert_eq!(cursor.batch_index, Some(3));
+    assert_eq!(cursor.timestamp, Some(1715000000));
+}

--- a/crates/rpc/tests/token_decode.rs
+++ b/crates/rpc/tests/token_decode.rs
@@ -1,0 +1,17 @@
+use circles_types::{Balance, TokenBalanceResponse};
+
+#[test]
+fn decode_token_balances() {
+    let raw: Vec<TokenBalanceResponse> =
+        serde_json::from_str(include_str!("fixtures/token_balances.json"))
+            .expect("parse token balances");
+    assert_eq!(raw.len(), 2);
+    match raw[0].balance {
+        Balance::Raw(v) => assert_eq!(v, alloy_primitives::U256::from(0x1234u64)),
+        _ => panic!("expected raw balance"),
+    }
+    match raw[1].balance {
+        Balance::Raw(v) => assert_eq!(v, alloy_primitives::U256::from(100000u64)),
+        _ => panic!("expected raw balance"),
+    }
+}

--- a/crates/rpc/tests/token_holder_decode.rs
+++ b/crates/rpc/tests/token_holder_decode.rs
@@ -1,0 +1,18 @@
+use circles_rpc::methods::token::TokenHolderNormalized;
+use circles_types::TokenHolder;
+
+#[test]
+fn decode_and_normalize_token_holders() {
+    let raw: Vec<TokenHolder> = serde_json::from_str(include_str!("fixtures/token_holders.json"))
+        .expect("parse token holders");
+    assert_eq!(raw.len(), 2);
+
+    let normalized: Vec<TokenHolderNormalized> =
+        raw.into_iter().map(TokenHolderNormalized::from).collect();
+
+    assert_eq!(
+        normalized[0].balance,
+        alloy_primitives::U256::from_str_radix("12345678901234567890", 10).unwrap()
+    );
+    assert_eq!(normalized[1].balance, alloy_primitives::U256::from(0));
+}

--- a/crates/rpc/tests/token_methods_normalized.rs
+++ b/crates/rpc/tests/token_methods_normalized.rs
@@ -1,0 +1,16 @@
+use circles_rpc::methods::token::TokenHolderNormalized;
+use circles_types::TokenHolder;
+use std::str::FromStr;
+
+#[test]
+fn normalize_token_holders() {
+    let raw: Vec<TokenHolder> = serde_json::from_str(include_str!("fixtures/token_holders.json"))
+        .expect("parse token holders");
+    let normalized: Vec<TokenHolderNormalized> =
+        raw.into_iter().map(TokenHolderNormalized::from).collect();
+    assert_eq!(
+        normalized[0].balance,
+        alloy_primitives::U256::from_str("12345678901234567890").unwrap()
+    );
+    assert_eq!(normalized[1].balance, alloy_primitives::U256::from(0));
+}

--- a/crates/rpc/tests/trust_decode.rs
+++ b/crates/rpc/tests/trust_decode.rs
@@ -1,0 +1,22 @@
+use circles_types::TrustRelation;
+
+#[test]
+fn decode_trust_relations() {
+    let rows: Vec<TrustRelation> =
+        serde_json::from_str(include_str!("fixtures/trust_relations.json"))
+            .expect("parse trust relations");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].truster,
+        "0xde374ece6fa50e781e81aac78e811b33d16912c7"
+            .parse::<alloy_primitives::Address>()
+            .unwrap()
+    );
+    assert_eq!(
+        rows[0].trustee,
+        "0xfeed00000000000000000000000000000000beef"
+            .parse::<alloy_primitives::Address>()
+            .unwrap()
+    );
+    assert_eq!(rows[0].expiry_time, 1800000000);
+}


### PR DESCRIPTION
- Introduce new `circles-rpc` crate: HTTP/WS client using Alloy providers, covering balance, token, trust, avatar/profile, query, events, invitation, pathfinder, group, tables, health, network, and search methods.
- Add `CirclesRpc` facade with `TryFrom<&str>`/`From<Url>` constructors, new WS constructors (feature-gated), and `paged_query`/`paged_stream` helpers wired to real `circles_query` responses.
- Implement paginator/cursor extraction, normalized token holders, invitation batching with bounded concurrency, and event parsing/subscription wrapper (best-effort unsubscribe).
- Include fixtures and tests for query decoding, events, token holders, trust, profiles; all `cargo test -p circles-rpc` passing.
- Add README and `paged_and_ws` example (configurable HTTP/WS URLs) demonstrating pagination and optional event subscription.