### PR TITLE
Add Circles SDK crate with core modules, registration/invites, examples, and live test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1118,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "circles-profiles"
+version = "0.1.0"
+dependencies = [
+ "circles-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "circles-rpc"
 version = "0.1.0"
 dependencies = [
@@ -1124,6 +1147,31 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "circles-sdk"
+version = "0.1.0"
+dependencies = [
+ "abis",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "bs58",
+ "circles-profiles",
+ "circles-rpc",
+ "circles-transfers",
+ "circles-types",
+ "futures",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1756,9 +1804,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1906,6 +1956,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2277,6 +2344,12 @@ checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
@@ -2695,6 +2768,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,6 +2962,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2841,6 +2970,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2848,6 +2979,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2855,6 +2987,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2988,6 +3121,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3573,6 +3707,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,6 +4139,16 @@ name = "web-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/pathfinder",
     "crates/abis",
     "crates/rpc",
+    "crates/sdk",
+    "crates/profiles",
     "crates/utils",
     "crates/transfers",
 ]

--- a/crates/profiles/Cargo.toml
+++ b/crates/profiles/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "circles-profiles"
+version = "0.1.0"
+edition = "2024"
+description = "Circles profile service client"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+circles-types = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
+serde = { workspace = true }
+serde_json = "1.0"
+thiserror = { workspace = true }
+tracing = "0.1"
+url = "2.5"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/profiles/src/lib.rs
+++ b/crates/profiles/src/lib.rs
@@ -110,7 +110,7 @@ struct PinResponse {
 
 fn endpoint(base: &Url, path: &str) -> Result<Url, ProfilesError> {
     base.join(path).map_err(|source| ProfilesError::InvalidUrl {
-        url: format!("{}{}", base, path),
+        url: format!("{base}{path}"),
         source,
     })
 }

--- a/crates/profiles/src/lib.rs
+++ b/crates/profiles/src/lib.rs
@@ -1,0 +1,150 @@
+//! Client for the Circles profile service (pin + fetch profile metadata).
+//! Mirrors the minimal behavior of the TypeScript `@profiles` package.
+
+pub use circles_types::{GroupProfile, Profile};
+use reqwest::{Client, StatusCode, Url};
+use thiserror::Error;
+
+/// Errors that can occur when interacting with the profile service.
+#[derive(Debug, Error)]
+pub enum ProfilesError {
+    /// The provided base URL was invalid.
+    #[error("invalid profile service url `{url}`: {source}")]
+    InvalidUrl {
+        url: String,
+        #[source]
+        source: url::ParseError,
+    },
+    /// The provided URL cannot be treated as a base for relative paths.
+    #[error("profile service url cannot be a base: {url}")]
+    CannotBeABase { url: String },
+    /// HTTP-layer error when sending or receiving requests.
+    #[error("request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    /// The service returned a non-success status during profile creation.
+    #[error("profile creation failed (status {status}): {body}")]
+    CreateFailed { status: StatusCode, body: String },
+    /// The service responded with an unexpected payload.
+    #[error("unexpected response format (status {status}): {body}")]
+    DecodeFailed { status: StatusCode, body: String },
+}
+
+/// Thin wrapper over the Circles profile service.
+#[derive(Debug, Clone)]
+pub struct Profiles {
+    base_url: Url,
+    client: Client,
+}
+
+impl Profiles {
+    /// Build a client using the default Reqwest client.
+    pub fn new(profile_service_url: impl AsRef<str>) -> Result<Self, ProfilesError> {
+        Self::with_client(profile_service_url, Client::new())
+    }
+
+    /// Build a client using a provided Reqwest client (useful for custom middleware or mocks).
+    pub fn with_client(
+        profile_service_url: impl AsRef<str>,
+        client: Client,
+    ) -> Result<Self, ProfilesError> {
+        let base_url = normalize_base_url(profile_service_url.as_ref())?;
+        Ok(Self { base_url, client })
+    }
+
+    /// Create and pin a profile, returning its CID.
+    pub async fn create(&self, profile: &Profile) -> Result<String, ProfilesError> {
+        let url = endpoint(&self.base_url, "pin")?;
+        let response = self.client.post(url).json(profile).send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            return Err(ProfilesError::CreateFailed { status, body });
+        }
+
+        let cid = serde_json::from_str::<PinResponse>(&body)
+            .map_err(|_| ProfilesError::DecodeFailed { status, body })?;
+        Ok(cid.cid)
+    }
+
+    /// Retrieve a profile by CID. Returns `Ok(None)` if the service responds with a non-success
+    /// status or if the body cannot be parsed.
+    pub async fn get(&self, cid: &str) -> Result<Option<Profile>, ProfilesError> {
+        let mut url = endpoint(&self.base_url, "get")?;
+        url.query_pairs_mut().append_pair("cid", cid);
+
+        let response = self.client.get(url).send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            tracing::warn!(
+                %status,
+                cid,
+                body = body.as_str(),
+                "failed to retrieve profile"
+            );
+            return Ok(None);
+        }
+
+        match serde_json::from_str(&body) {
+            Ok(profile) => Ok(Some(profile)),
+            Err(err) => {
+                tracing::warn!(
+                    %status,
+                    cid,
+                    body = body.as_str(),
+                    error = %err,
+                    "failed to parse profile response"
+                );
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PinResponse {
+    cid: String,
+}
+
+fn endpoint(base: &Url, path: &str) -> Result<Url, ProfilesError> {
+    base.join(path).map_err(|source| ProfilesError::InvalidUrl {
+        url: format!("{}{}", base, path),
+        source,
+    })
+}
+
+fn normalize_base_url(raw: &str) -> Result<Url, ProfilesError> {
+    let mut url = Url::parse(raw).map_err(|source| ProfilesError::InvalidUrl {
+        url: raw.to_owned(),
+        source,
+    })?;
+
+    if !url.path().ends_with('/') {
+        url.path_segments_mut()
+            .map_err(|_| ProfilesError::CannotBeABase {
+                url: raw.to_owned(),
+            })?
+            .push("");
+    }
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_base_url;
+
+    #[test]
+    fn ensures_trailing_slash() {
+        let normalized = normalize_base_url("https://example.com/api").unwrap();
+        assert_eq!(normalized.as_str(), "https://example.com/api/");
+    }
+
+    #[test]
+    fn keeps_existing_slash() {
+        let normalized = normalize_base_url("https://example.com/api/").unwrap();
+        assert_eq!(normalized.as_str(), "https://example.com/api/");
+    }
+}

--- a/crates/profiles/tests/profile_service.rs
+++ b/crates/profiles/tests/profile_service.rs
@@ -1,0 +1,70 @@
+use circles_profiles::{Profile, Profiles};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const PROFILE_SERVICE_URL: &str = "https://rpc.aboutcircles.com/profiles/";
+const RUN_LIVE_PROFILE_TESTS: &str = "RUN_LIVE_PROFILE_TESTS";
+
+/// Ignored by default: requires network access and a `PROFILE_CID` environment variable.
+#[tokio::test]
+#[ignore = "requires PROFILE_CID env var and network access"]
+async fn fetch_profile_when_cid_provided() {
+    let cid = match std::env::var("PROFILE_CID") {
+        Ok(cid) => cid,
+        Err(_) => {
+            eprintln!("skipping: set PROFILE_CID to run this integration test");
+            return;
+        }
+    };
+
+    let client = Profiles::new(PROFILE_SERVICE_URL).expect("valid profile service url");
+    let profile = client.get(&cid).await.expect("profile fetch request");
+    let profile = profile.expect("expected profile to exist");
+    println!("Fetched profile for {}: {:?}", cid, profile);
+}
+
+/// Ignored by default: hits the live profile service to pin and fetch a profile.
+#[tokio::test]
+#[ignore = "requires RUN_LIVE_PROFILE_TESTS=1 and network access"]
+async fn create_and_fetch_round_trip() {
+    if std::env::var(RUN_LIVE_PROFILE_TESTS).ok().as_deref() != Some("1") {
+        eprintln!("skipping: set RUN_LIVE_PROFILE_TESTS=1 to run this integration test");
+        return;
+    }
+
+    let client = Profiles::new(PROFILE_SERVICE_URL).expect("valid profile service url");
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_secs();
+    let profile = Profile {
+        // Keep name short (<36 chars) to satisfy service validation
+        name: format!("profiles-integration-{ts}"),
+        description: Some("integration test profile".to_string()),
+        preview_image_url: None,
+        image_url: None,
+        location: None,
+        geo_location: None,
+        extensions: None,
+    };
+
+    let cid = client.create(&profile).await.expect("profile creation");
+    assert!(
+        !cid.is_empty(),
+        "service returned an empty cid for created profile"
+    );
+
+    let fetched = client
+        .get(&cid)
+        .await
+        .expect("profile fetch request")
+        .expect("expected freshly created profile to exist");
+    assert_eq!(fetched.name, profile.name);
+    assert_eq!(fetched.description, profile.description);
+    assert_eq!(fetched.preview_image_url, profile.preview_image_url);
+
+    println!(
+        "Created + fetched profile: cid={cid}, profile={:?}",
+        fetched
+    );
+}

--- a/crates/profiles/tests/profile_service.rs
+++ b/crates/profiles/tests/profile_service.rs
@@ -19,7 +19,7 @@ async fn fetch_profile_when_cid_provided() {
     let client = Profiles::new(PROFILE_SERVICE_URL).expect("valid profile service url");
     let profile = client.get(&cid).await.expect("profile fetch request");
     let profile = profile.expect("expected profile to exist");
-    println!("Fetched profile for {}: {:?}", cid, profile);
+    println!("Fetched profile for {cid}: {profile:?}");
 }
 
 /// Ignored by default: hits the live profile service to pin and fetch a profile.
@@ -63,8 +63,5 @@ async fn create_and_fetch_round_trip() {
     assert_eq!(fetched.description, profile.description);
     assert_eq!(fetched.preview_image_url, profile.preview_image_url);
 
-    println!(
-        "Created + fetched profile: cid={cid}, profile={:?}",
-        fetched
-    );
+    println!("Created + fetched profile: cid={cid}, profile={fetched:?}");
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "circles-sdk"
+version = "0.1.0"
+edition = "2024"
+description = "Circles SDK orchestrating RPC, profiles, pathfinding, transfers, and contract runners."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+alloy-primitives = { workspace = true }
+async-trait = "0.1"
+circles-profiles = { path = "../profiles" }
+circles-rpc = { path = "../rpc" }
+circles-types = { workspace = true }
+circles-transfers = { path = "../transfers" }
+abis = { path = "../abis" }
+thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+alloy-provider = { version = "1.1.2", features = ["reqwest"] }
+alloy-sol-types = "1.4.1"
+bs58 = "0.5"
+serde_json = "1.0"
+rand = "0.8"
+hex = "0.4"
+futures = { version = "0.3", optional = true }
+alloy-json-rpc = { version = "1.1.2", optional = true }
+tracing = { version = "0.1", optional = true }
+once_cell = "1.19"
+
+[features]
+default = []
+ws = ["circles-rpc/ws", "futures", "alloy-json-rpc", "tokio", "tracing"]
+
+[dev-dependencies]
+futures = "0.3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -1,0 +1,48 @@
+# Circles SDK (Rust)
+
+Rust port of the Circles TypeScript SDK, orchestrating Circles RPC, profiles, pathfinding, transfers, and contract runners.
+
+## Features
+
+- Avatar helpers (human/org/group) for balances, trust, profiles, and registration.
+- Invitation/referral flows (invite generation, escrow redeem/checks).
+- Transfer planning (via `circles-transfers`) and pathfinding helpers.
+- Websocket subscriptions with retry/backoff and optional HTTP catch-up.
+
+## Quickstart
+
+```rust
+use circles_sdk::{config, Sdk};
+use alloy_primitives::address;
+use circles_types::CirclesConfig;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Gnosis chain (100) mainnet config
+    let config: CirclesConfig = config::gnosis_mainnet();
+    let sdk = Sdk::new(config, None)?;
+    let avatar = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let info = sdk.avatar_info(avatar).await?;
+    println!("avatar type: {:?}", info.avatar_type);
+    Ok(())
+}
+```
+
+Examples live under `examples/`:
+- `basic_read.rs`: fetch avatar info/balances/trust and run a pathfind.
+- `invite_generate.rs`: build invitation secrets/signers and inspect txs.
+- `ws_subscribe.rs` (feature `ws`): subscribe with retries + catch-up.
+
+## Tests
+
+Unit tests are minimal; run with:
+```
+cargo test -p circles-sdk
+cargo test -p circles-sdk --features ws
+```
+
+## Notes
+
+- The SDK is runner-agnostic: provide a `ContractRunner` for write paths; omit for read-only.
+- Pathfinding/transfer helpers default to using wrapped balances; adjust `AdvancedTransferOptions` as needed.
+- WS helpers tolerate heartbeats/batches and expose retry/catch-up utilities.

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -41,6 +41,12 @@ cargo test -p circles-sdk
 cargo test -p circles-sdk --features ws
 ```
 
+Optional live checks (ignored by default):
+```
+RUN_LIVE=1 LIVE_AVATAR=0x... cargo test -p circles-sdk -- --ignored
+```
+You can override endpoints with `CIRCLES_RPC_URL`, `CIRCLES_PATHFINDER_URL`, and `CIRCLES_PROFILE_URL`.
+
 ## Notes
 
 - The SDK is runner-agnostic: provide a `ContractRunner` for write paths; omit for read-only.

--- a/crates/sdk/examples/README.md
+++ b/crates/sdk/examples/README.md
@@ -1,0 +1,5 @@
+# Circles SDK Examples
+
+- `basic_read.rs`: Fetch avatar info, balances, trust, and pathfind (uses shared mainnet config).
+- `ws_subscribe.rs` (requires `--features ws`): Subscribe to events with retries/catch-up.
+- `invite_generate.rs`: Generate invitation secrets/signers and inspect prepared txs (no send; uses shared mainnet config).

--- a/crates/sdk/examples/basic_read.rs
+++ b/crates/sdk/examples/basic_read.rs
@@ -1,0 +1,46 @@
+use alloy_primitives::address;
+use circles_sdk::{Sdk, config};
+use circles_types::AdvancedTransferOptions;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Minimal config: uses circles_types::CirclesConfig defaults if you pass your own.
+    // Here we hardcode mainnet endpoints (replace with env/config as needed).
+    let config = config::gnosis_mainnet();
+
+    let sdk = Sdk::new(config, None)?;
+    let avatar = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    let info = sdk.avatar_info(avatar).await?;
+    println!("Avatar info: {:?}", info.avatar_type);
+
+    let balances = sdk.data_balances(avatar, true, true).await?;
+    println!("Balances entries: {}", balances.len());
+
+    let trust = sdk.data_trust(avatar).await?;
+    println!("Trust relations: {}", trust.len());
+
+    // Pathfind self to self (max flow) as a demo (requires Human avatar).
+    if let circles_sdk::Avatar::Human(human) = sdk.get_avatar(avatar).await? {
+        let max_flow = human
+            .max_flow_to(
+                avatar,
+                Some(AdvancedTransferOptions {
+                    use_wrapped_balances: Some(true),
+                    from_tokens: None,
+                    to_tokens: None,
+                    exclude_from_tokens: None,
+                    exclude_to_tokens: None,
+                    simulated_balances: None,
+                    max_transfers: None,
+                    tx_data: None,
+                }),
+            )
+            .await?;
+        println!("Max flow: {}", max_flow.max_flow);
+    } else {
+        println!("Avatar is not human; skipping pathfind demo");
+    }
+
+    Ok(())
+}

--- a/crates/sdk/examples/invite_generate.rs
+++ b/crates/sdk/examples/invite_generate.rs
@@ -1,0 +1,26 @@
+use alloy_primitives::address;
+use circles_sdk::{Sdk, config};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Replace with real config/addresses; this example only builds txs and prints them.
+    let config = config::gnosis_mainnet();
+
+    let sdk = Sdk::new(config, None)?;
+    let avatar = sdk
+        .get_avatar(address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+        .await?;
+
+    if let circles_sdk::Avatar::Human(h) = avatar {
+        let generated = h.generate_invites(2).await?;
+        println!("Secrets: {:?}", generated.secrets);
+        println!("Signers: {:?}", generated.signers);
+        for (i, tx) in generated.txs.iter().enumerate() {
+            println!("Tx {i}: to={:?}, data_len={}", tx.to, tx.data.len());
+        }
+    } else {
+        println!("Avatar not human; cannot generate invites");
+    }
+
+    Ok(())
+}

--- a/crates/sdk/examples/ws_subscribe.rs
+++ b/crates/sdk/examples/ws_subscribe.rs
@@ -1,0 +1,39 @@
+#![cfg_attr(not(feature = "ws"), allow(dead_code, unused_imports))]
+
+use alloy_primitives::address;
+#[cfg(feature = "ws")]
+use circles_sdk::ws;
+use circles_sdk::{Sdk, config};
+use circles_types::CirclesConfig;
+
+#[cfg(feature = "ws")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config: CirclesConfig = config::gnosis_mainnet();
+
+    let sdk = Sdk::new(config, None)?;
+    let avatar = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let ws_url = "wss://rpc.aboutcircles.com/ws";
+
+    // Default filter: address of the avatar.
+    let filter = serde_json::json!({ "address": format!("{:#x}", avatar) });
+    let (catch_up, sub) = sdk
+        .subscribe_events_ws_with_catchup(ws_url, filter, Some(3), None, None)
+        .await?;
+
+    println!("Catch-up events: {}", catch_up.len());
+
+    let handle = ws::spawn_event_handler(sub, move |evt| {
+        println!("Event: {:?}", evt.event_type);
+    });
+
+    // Run for a short time then exit.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    handle.abort();
+    Ok(())
+}
+
+#[cfg(not(feature = "ws"))]
+fn main() {
+    println!("ws_subscribe example requires --features ws");
+}

--- a/crates/sdk/src/avatar/base_group.rs
+++ b/crates/sdk/src/avatar/base_group.rs
@@ -1,0 +1,149 @@
+use crate::avatar::common::CommonAvatar;
+use crate::cid_v0_to_digest::cid_v0_to_digest;
+use crate::{
+    ContractRunner, Core, PreparedTransaction, Profile, SdkError, SubmittedTx, call_to_tx,
+};
+use abis::BaseGroup;
+use alloy_primitives::{Address, U256, aliases::U96};
+use circles_profiles::Profiles;
+use circles_rpc::CirclesRpc;
+#[cfg(feature = "ws")]
+use circles_rpc::events::subscription::CirclesSubscription;
+#[cfg(feature = "ws")]
+use circles_types::CirclesEvent;
+use circles_types::{
+    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+};
+use std::sync::Arc;
+
+/// Top-level avatar enum variant: base group.
+pub struct BaseGroupAvatar {
+    pub address: Address,
+    pub info: AvatarInfo,
+    pub core: Arc<Core>,
+    pub runner: Option<Arc<dyn ContractRunner>>,
+    pub common: CommonAvatar,
+}
+
+impl BaseGroupAvatar {
+    pub async fn balances(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        self.common.balances(as_time_circles, use_v2).await
+    }
+
+    pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
+        self.common.trust_relations().await
+    }
+
+    pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
+        self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
+        let cid = self.common.pin_profile(profile).await?;
+        let digest = cid_v0_to_digest(&cid)?;
+        let call = abis::BaseGroup::updateMetadataDigestCall {
+            _metadataDigest: digest,
+        };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    pub async fn trust_add(
+        &self,
+        avatars: &[Address],
+        expiry: u128,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let runner = self.runner.clone().ok_or(SdkError::MissingRunner)?;
+        let txs = avatars
+            .iter()
+            .map(|addr| BaseGroup::trustCall {
+                _trustReceiver: *addr,
+                _expiry: U96::from(expiry),
+            })
+            .map(|call| call_to_tx(self.address, call, None))
+            .collect();
+        Ok(runner.send_transactions(txs).await?)
+    }
+
+    pub async fn trust_remove(&self, avatars: &[Address]) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.trust_add(avatars, 0).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws(
+        &self,
+        ws_url: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        self.common.subscribe_events_ws(ws_url, filter).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_retries(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        self.common
+            .subscribe_events_ws_with_retries(ws_url, filter, max_attempts)
+            .await
+    }
+
+    pub async fn plan_transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        self.common.plan_transfer(to, amount, options).await
+    }
+
+    pub async fn transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.common.transfer(to, amount, options).await
+    }
+
+    pub async fn find_path(
+        &self,
+        to: Address,
+        target_flow: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.find_path(to, target_flow, options).await
+    }
+
+    pub async fn max_flow_to(
+        &self,
+        to: Address,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.max_flow_to(to, options).await
+    }
+
+    pub fn new(
+        address: Address,
+        info: AvatarInfo,
+        core: Arc<Core>,
+        profiles: Profiles,
+        rpc: Arc<CirclesRpc>,
+        runner: Option<Arc<dyn ContractRunner>>,
+    ) -> Self {
+        let common = CommonAvatar::new(address, core.clone(), profiles, rpc, runner.clone());
+        Self {
+            address,
+            info,
+            core,
+            runner,
+            common,
+        }
+    }
+}

--- a/crates/sdk/src/avatar/common.rs
+++ b/crates/sdk/src/avatar/common.rs
@@ -1,0 +1,191 @@
+#[cfg(feature = "ws")]
+use crate::ws;
+use crate::{ContractRunner, Core, PreparedTransaction, Profile, SdkError};
+use alloy_primitives::{Address, U256};
+use circles_profiles::Profiles;
+use circles_rpc::CirclesRpc;
+#[cfg(feature = "ws")]
+use circles_rpc::events::subscription::CirclesSubscription;
+use circles_transfers::TransferBuilder;
+use circles_types::{
+    AdvancedTransferOptions, PathfindingResult, TokenBalanceResponse, TrustRelation,
+};
+#[cfg(feature = "ws")]
+use circles_types::{CirclesEvent, Filter};
+#[cfg(feature = "ws")]
+use serde_json::json;
+use std::sync::Arc;
+
+/// Shared avatar context and read helpers.
+pub struct CommonAvatar {
+    pub address: Address,
+    pub core: Arc<Core>,
+    pub profiles: Profiles,
+    pub rpc: Arc<CirclesRpc>,
+    pub runner: Option<Arc<dyn ContractRunner>>,
+}
+
+impl CommonAvatar {
+    pub fn new(
+        address: Address,
+        core: Arc<Core>,
+        profiles: Profiles,
+        rpc: Arc<CirclesRpc>,
+        runner: Option<Arc<dyn ContractRunner>>,
+    ) -> Self {
+        Self {
+            address,
+            core,
+            profiles,
+            rpc,
+            runner,
+        }
+    }
+
+    /// Get detailed token balances (v1/v2 selectable).
+    pub async fn balances(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        Ok(self
+            .rpc
+            .token()
+            .get_token_balances(self.address, as_time_circles, use_v2)
+            .await?)
+    }
+
+    /// Get trust relations.
+    pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
+        Ok(self.rpc.trust().get_trust_relations(self.address).await?)
+    }
+
+    /// Fetch profile by CID if present.
+    pub async fn profile(&self, cid: Option<&str>) -> Result<Option<Profile>, SdkError> {
+        if let Some(cid) = cid {
+            Ok(self.profiles.get(cid).await?)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Upload profile to the profile service, returning the new CID.
+    pub async fn pin_profile(&self, profile: &Profile) -> Result<String, SdkError> {
+        Ok(self.profiles.create(profile).await?)
+    }
+
+    /// Submit transactions via runner (helper).
+    pub async fn send(
+        &self,
+        txs: Vec<PreparedTransaction>,
+    ) -> Result<Vec<crate::SubmittedTx>, SdkError> {
+        let runner = self.runner.clone().ok_or(SdkError::MissingRunner)?;
+        Ok(runner.send_transactions(txs).await?)
+    }
+
+    /// Plan a transfer using the transfer builder (no submit). Returns ordered prepared txs.
+    pub async fn plan_transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let builder = TransferBuilder::new(self.core.config.clone())?;
+        let txs = builder
+            .construct_advanced_transfer(self.address, to, amount, options)
+            .await?;
+        Ok(txs
+            .into_iter()
+            .map(|tx| PreparedTransaction {
+                to: tx.to,
+                data: tx.data,
+                value: Some(tx.value),
+            })
+            .collect())
+    }
+
+    /// Plan and execute a transfer using the runner (if present).
+    pub async fn transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<crate::SubmittedTx>, SdkError> {
+        let txs = self.plan_transfer(to, amount, options).await?;
+        self.send(txs).await
+    }
+
+    /// Find a path between this avatar and `to` with a target flow (defaults use_wrapped_balances=true).
+    pub async fn find_path(
+        &self,
+        to: Address,
+        target_flow: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        let opts = options.unwrap_or_else(|| AdvancedTransferOptions {
+            use_wrapped_balances: Some(true),
+            from_tokens: None,
+            to_tokens: None,
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            max_transfers: None,
+            tx_data: None,
+        });
+        let params = opts.to_find_path_params(self.address, to, target_flow);
+        Ok(self.rpc.pathfinder().find_path(params).await?)
+    }
+
+    /// Max-flow helper: sets target_flow to U256::MAX.
+    pub async fn max_flow_to(
+        &self,
+        to: Address,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.find_path(to, U256::MAX, options).await
+    }
+
+    /// Subscribe to Circles events for this avatar via websocket.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws(
+        &self,
+        ws_url: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        let filt = filter.unwrap_or_else(|| json!({ "address": format!("{:#x}", self.address) }));
+        ws::subscribe_with_retries(ws_url, filt, None).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_retries(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        ws::subscribe_with_retries(ws_url, filter, max_attempts).await
+    }
+
+    /// Subscribe with retries and optionally fetch HTTP events for a catch-up range.
+    /// Returns (catch_up_events, live_subscription).
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_catchup(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+        catch_up_from_block: Option<u64>,
+        catch_up_filter: Option<Vec<Filter>>,
+    ) -> Result<(Vec<CirclesEvent>, CirclesSubscription<CirclesEvent>), SdkError> {
+        ws::subscribe_with_catchup(
+            &self.rpc,
+            ws_url,
+            filter,
+            max_attempts,
+            catch_up_from_block,
+            catch_up_filter,
+            Some(self.address),
+        )
+        .await
+    }
+}

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -1,0 +1,386 @@
+use crate::avatar::common::CommonAvatar;
+use crate::cid_v0_to_digest::cid_v0_to_digest;
+use crate::runner::{PreparedTransaction as RunnerTx, SubmittedTx as RunnerSubmitted};
+use crate::{
+    ContractRunner, Core, PreparedTransaction, Profile, SdkError, SubmittedTx, call_to_tx,
+};
+use abis::{HubV2, InvitationFarm, ReferralsModule};
+use alloy_primitives::{Address, U256, aliases::U96};
+use alloy_sol_types::{SolCall, SolValue, sol};
+use circles_profiles::Profiles;
+use circles_rpc::CirclesRpc;
+#[cfg(feature = "ws")]
+use circles_rpc::events::subscription::CirclesSubscription;
+#[cfg(feature = "ws")]
+use circles_types::CirclesEvent;
+use circles_types::{
+    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+};
+use hex::encode as hex_encode;
+use rand::RngCore;
+use std::sync::Arc;
+
+/// Top-level avatar enum variant: human.
+pub struct HumanAvatar {
+    pub address: Address,
+    pub info: AvatarInfo,
+    pub core: Arc<Core>,
+    pub runner: Option<Arc<dyn ContractRunner>>,
+    pub common: CommonAvatar,
+}
+
+/// Invitation generation result (secrets + signers + prepared txs).
+#[derive(Debug, Clone)]
+pub struct GeneratedInvites {
+    pub secrets: Vec<String>,
+    pub signers: Vec<Address>,
+    pub txs: Vec<RunnerTx>,
+    pub submitted: Option<Vec<RunnerSubmitted>>,
+}
+
+sol! {
+    struct ReferralPayload {
+        address referralsModule;
+        bytes callData;
+    }
+}
+
+impl HumanAvatar {
+    /// Get detailed token balances (v1/v2 selectable).
+    pub async fn balances(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        self.common.balances(as_time_circles, use_v2).await
+    }
+
+    /// Get trust relations.
+    pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
+        self.common.trust_relations().await
+    }
+
+    /// Fetch profile (cached by CID in memory).
+    pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
+        self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    /// Update profile via profiles service and store CID through NameRegistry.
+    /// Requires runner.
+    pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
+        let cid = self.common.pin_profile(profile).await?;
+        let digest = cid_v0_to_digest(&cid)?;
+        let call = abis::NameRegistry::updateMetadataDigestCall {
+            _metadataDigest: digest,
+        };
+        let tx = call_to_tx(self.core.config.name_registry_address, call, None);
+        let sent = self.common.send(vec![tx]).await?;
+        Ok(sent)
+    }
+
+    /// Trust one or more avatars via HubV2::trust. Requires runner.
+    pub async fn trust_add(
+        &self,
+        avatars: &[Address],
+        expiry: u128,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let runner = self.runner.clone().ok_or(SdkError::MissingRunner)?;
+        let txs = avatars
+            .iter()
+            .map(|addr| HubV2::trustCall {
+                _trustReceiver: *addr,
+                _expiry: U96::from(expiry),
+            })
+            .map(|call| call_to_tx(self.core.config.v2_hub_address, call, None))
+            .collect();
+        Ok(runner.send_transactions(txs).await?)
+    }
+
+    /// Remove trust (sets expiry to 0). Requires runner.
+    pub async fn trust_remove(&self, avatars: &[Address]) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.trust_add(avatars, 0).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws(
+        &self,
+        ws_url: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        self.common.subscribe_events_ws(ws_url, filter).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_retries(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        self.common
+            .subscribe_events_ws_with_retries(ws_url, filter, max_attempts)
+            .await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_catchup(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+        catch_up_from_block: Option<u64>,
+        catch_up_filter: Option<Vec<circles_types::Filter>>,
+    ) -> Result<(Vec<CirclesEvent>, CirclesSubscription<CirclesEvent>), SdkError> {
+        self.common
+            .subscribe_events_ws_with_catchup(
+                ws_url,
+                filter,
+                max_attempts,
+                catch_up_from_block,
+                catch_up_filter,
+            )
+            .await
+    }
+
+    /// Plan a transfer without submitting.
+    pub async fn plan_transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        self.common.plan_transfer(to, amount, options).await
+    }
+
+    /// Execute a transfer using the runner (requires runner).
+    pub async fn transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.common.transfer(to, amount, options).await
+    }
+
+    pub async fn find_path(
+        &self,
+        to: Address,
+        target_flow: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.find_path(to, target_flow, options).await
+    }
+
+    pub async fn max_flow_to(
+        &self,
+        to: Address,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.max_flow_to(to, options).await
+    }
+
+    /// Generate invitation secrets/signers and return prepared transactions (claim + batch transfer).
+    pub async fn generate_invites(
+        &self,
+        number_of_invites: u64,
+    ) -> Result<GeneratedInvites, SdkError> {
+        if number_of_invites == 0 {
+            return Err(SdkError::InvalidRegistration(
+                "number_of_invites must be greater than 0".to_string(),
+            ));
+        }
+
+        // Simulate claim to retrieve ids
+        let claim_call = InvitationFarm::claimInvitesCall {
+            numberOfInvites: U256::from(number_of_invites),
+        };
+        let ids = self
+            .common
+            .core
+            .invitation_farm()
+            .claimInvites(U256::from(number_of_invites))
+            .call()
+            .await
+            .unwrap_or_default();
+        if ids.is_empty() {
+            return Err(SdkError::InvalidRegistration(
+                "invitation farm returned no ids".to_string(),
+            ));
+        }
+
+        // Secrets/signers
+        let mut secrets = Vec::with_capacity(ids.len());
+        let mut signers = Vec::with_capacity(ids.len());
+        for _ in &ids {
+            let mut buf = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut buf);
+            secrets.push(format!("0x{}", hex_encode(buf)));
+            // Derive pseudo signer as lowercased hex address (no checksum)
+            let signer = Address::from_slice(&buf[12..]);
+            signers.push(signer);
+        }
+
+        // Referral payload
+        let create_accounts = ReferralsModule::createAccountsCall {
+            signers: signers.clone(),
+        };
+        let referrals_module = self.common.core.config.referrals_module_address;
+        let payload = ReferralPayload {
+            referralsModule: referrals_module,
+            callData: create_accounts.abi_encode().into(),
+        };
+        let encoded_payload = payload.abi_encode();
+
+        // Amounts: 96 CRC each
+        let amount = U256::from(96u128) * U256::from(10).pow(U256::from(18));
+        let values = vec![amount; ids.len()];
+
+        // Build txs: claimInvites + safeBatchTransferFrom to invitation module
+        let invitation_module = self
+            .common
+            .core
+            .invitation_farm()
+            .invitationModule()
+            .call()
+            .await
+            .unwrap_or_default();
+
+        let claim_tx = call_to_tx(
+            self.common.core.config.invitation_farm_address,
+            claim_call,
+            None,
+        );
+        let batch_call = HubV2::safeBatchTransferFromCall {
+            _from: self.address,
+            _to: invitation_module,
+            _ids: ids,
+            _values: values,
+            _data: encoded_payload.into(),
+        };
+        let batch_tx = call_to_tx(self.common.core.config.v2_hub_address, batch_call, None);
+
+        Ok(GeneratedInvites {
+            secrets,
+            signers,
+            txs: vec![
+                RunnerTx {
+                    to: claim_tx.to,
+                    data: claim_tx.data,
+                    value: claim_tx.value,
+                },
+                RunnerTx {
+                    to: batch_tx.to,
+                    data: batch_tx.data,
+                    value: batch_tx.value,
+                },
+            ],
+            submitted: None,
+        })
+    }
+
+    /// Invitation rows (RPC helper).
+    pub async fn invitations(
+        &self,
+    ) -> Result<Vec<circles_rpc::methods::invitation::InvitationRow>, SdkError> {
+        Ok(self
+            .common
+            .rpc
+            .invitation()
+            .get_invitations(self.address)
+            .await?)
+    }
+
+    /// Redeem an invitation from an inviter (requires runner).
+    pub async fn redeem_invitation(&self, inviter: Address) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = abis::InvitationEscrow::redeemInvitationCall { inviter };
+        let tx = call_to_tx(
+            self.common.core.config.invitation_escrow_address,
+            call,
+            None,
+        );
+        self.common.send(vec![tx]).await
+    }
+
+    /// Revoke a specific invitation (requires runner).
+    pub async fn revoke_invitation(&self, invitee: Address) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = abis::InvitationEscrow::revokeInvitationCall { invitee };
+        let tx = call_to_tx(
+            self.common.core.config.invitation_escrow_address,
+            call,
+            None,
+        );
+        self.common.send(vec![tx]).await
+    }
+
+    /// Revoke all invitations sent by this avatar (requires runner).
+    pub async fn revoke_all_invitations(&self) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = abis::InvitationEscrow::revokeAllInvitationsCall {};
+        let tx = call_to_tx(
+            self.common.core.config.invitation_escrow_address,
+            call,
+            None,
+        );
+        self.common.send(vec![tx]).await
+    }
+
+    pub fn new(
+        address: Address,
+        info: AvatarInfo,
+        core: Arc<Core>,
+        profiles: Profiles,
+        rpc: Arc<CirclesRpc>,
+        runner: Option<Arc<dyn ContractRunner>>,
+    ) -> Self {
+        let common = CommonAvatar::new(address, core.clone(), profiles, rpc, runner.clone());
+        Self {
+            address,
+            info,
+            core,
+            runner,
+            common,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, address};
+
+    #[test]
+    fn referral_payload_encodes() {
+        let signers = vec![address!("1000000000000000000000000000000000000001")];
+        let create_accounts = ReferralsModule::createAccountsCall {
+            signers: signers.clone(),
+        };
+        let payload = ReferralPayload {
+            referralsModule: address!("2000000000000000000000000000000000000002"),
+            callData: create_accounts.abi_encode().into(),
+        };
+        let bytes = payload.abi_encode();
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn batch_tx_targets_hub() {
+        let ids = vec![U256::from(1), U256::from(2)];
+        let amount = U256::from(96u128) * U256::from(10).pow(U256::from(18));
+        let values = vec![amount; ids.len()];
+        let batch_call = HubV2::safeBatchTransferFromCall {
+            _from: address!("aaaa000000000000000000000000000000000000"),
+            _to: address!("bbbb000000000000000000000000000000000000"),
+            _ids: ids,
+            _values: values,
+            _data: Bytes::default(),
+        };
+        let batch_tx = call_to_tx(
+            address!("cccc000000000000000000000000000000000000"),
+            batch_call,
+            None,
+        );
+        assert_eq!(
+            batch_tx.to,
+            address!("cccc000000000000000000000000000000000000")
+        );
+    }
+}

--- a/crates/sdk/src/avatar/mod.rs
+++ b/crates/sdk/src/avatar/mod.rs
@@ -1,0 +1,8 @@
+pub mod base_group;
+pub mod common;
+pub mod human;
+pub mod organisation;
+
+pub use base_group::BaseGroupAvatar;
+pub use human::HumanAvatar;
+pub use organisation::OrganisationAvatar;

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -1,0 +1,137 @@
+use crate::avatar::common::CommonAvatar;
+use crate::cid_v0_to_digest::cid_v0_to_digest;
+use crate::{
+    ContractRunner, Core, PreparedTransaction, Profile, SdkError, SubmittedTx, call_to_tx,
+};
+use abis::HubV2;
+use alloy_primitives::{Address, U256, aliases::U96};
+use circles_profiles::Profiles;
+use circles_rpc::CirclesRpc;
+#[cfg(feature = "ws")]
+use circles_rpc::events::subscription::CirclesSubscription;
+#[cfg(feature = "ws")]
+use circles_types::CirclesEvent;
+use circles_types::{
+    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+};
+use std::sync::Arc;
+
+/// Top-level avatar enum variant: organisation.
+pub struct OrganisationAvatar {
+    pub address: Address,
+    pub info: AvatarInfo,
+    pub core: Arc<Core>,
+    pub runner: Option<Arc<dyn ContractRunner>>,
+    pub common: CommonAvatar,
+}
+
+impl OrganisationAvatar {
+    pub async fn balances(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        self.common.balances(as_time_circles, use_v2).await
+    }
+
+    pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
+        self.common.trust_relations().await
+    }
+
+    pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
+        self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
+        let cid = self.common.pin_profile(profile).await?;
+        let digest = cid_v0_to_digest(&cid)?;
+        let call = abis::NameRegistry::updateMetadataDigestCall {
+            _metadataDigest: digest,
+        };
+        let tx = call_to_tx(self.core.config.name_registry_address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    pub async fn trust_add(
+        &self,
+        avatars: &[Address],
+        expiry: u128,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let runner = self.runner.clone().ok_or(SdkError::MissingRunner)?;
+        let txs = avatars
+            .iter()
+            .map(|addr| HubV2::trustCall {
+                _trustReceiver: *addr,
+                _expiry: U96::from(expiry),
+            })
+            .map(|call| call_to_tx(self.core.config.v2_hub_address, call, None))
+            .collect();
+        Ok(runner.send_transactions(txs).await?)
+    }
+
+    pub async fn trust_remove(&self, avatars: &[Address]) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.trust_add(avatars, 0).await
+    }
+
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws(
+        &self,
+        ws_url: &str,
+        filter: Option<serde_json::Value>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        self.common.subscribe_events_ws(ws_url, filter).await
+    }
+
+    pub async fn plan_transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        self.common.plan_transfer(to, amount, options).await
+    }
+
+    pub async fn transfer(
+        &self,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.common.transfer(to, amount, options).await
+    }
+
+    pub async fn find_path(
+        &self,
+        to: Address,
+        target_flow: U256,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.find_path(to, target_flow, options).await
+    }
+
+    pub async fn max_flow_to(
+        &self,
+        to: Address,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<PathfindingResult, SdkError> {
+        self.common.max_flow_to(to, options).await
+    }
+
+    pub fn new(
+        address: Address,
+        info: AvatarInfo,
+        core: Arc<Core>,
+        profiles: Profiles,
+        rpc: Arc<CirclesRpc>,
+        runner: Option<Arc<dyn ContractRunner>>,
+    ) -> Self {
+        let common = CommonAvatar::new(address, core.clone(), profiles, rpc, runner.clone());
+        Self {
+            address,
+            info,
+            core,
+            runner,
+            common,
+        }
+    }
+}

--- a/crates/sdk/src/cid_v0_to_digest.rs
+++ b/crates/sdk/src/cid_v0_to_digest.rs
@@ -1,0 +1,34 @@
+use alloy_primitives::FixedBytes;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CidError {
+    #[error("invalid base58 cid: {0}")]
+    InvalidCid(String),
+    #[error("cid digest must be 32 bytes, got {0} bytes")]
+    InvalidLength(usize),
+}
+
+/// Convert CIDv0 (base58btc) to bytes32 digest.
+pub fn cid_v0_to_digest(cid: &str) -> Result<FixedBytes<32>, CidError> {
+    let data = bs58::decode(cid)
+        .into_vec()
+        .map_err(|e| CidError::InvalidCid(e.to_string()))?;
+    // CIDv0 = 0x12 0x20 + 32-byte multihash digest
+    if data.len() != 34 {
+        return Err(CidError::InvalidLength(data.len()));
+    }
+    Ok(FixedBytes::from_slice(&data[2..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cid_v0_to_digest;
+
+    #[test]
+    fn cid_roundtrip_length() {
+        let cid = "QmfDWxB9jtEGHLi6ToJKWyoXeRzu64WBSKUfnwCWKHLsFn";
+        let digest = cid_v0_to_digest(cid).unwrap();
+        assert_eq!(digest.len(), 32);
+    }
+}

--- a/crates/sdk/src/config.rs
+++ b/crates/sdk/src/config.rs
@@ -1,0 +1,26 @@
+use alloy_primitives::address;
+use circles_types::CirclesConfig;
+use once_cell::sync::Lazy;
+
+/// Gnosis Chain (100) mainnet Circles configuration.
+pub static GNOSIS_MAINNET: Lazy<CirclesConfig> = Lazy::new(|| CirclesConfig {
+    circles_rpc_url: "https://rpc.aboutcircles.com/".to_string(),
+    pathfinder_url: "https://pathfinder.aboutcircles.com".to_string(),
+    profile_service_url: "https://rpc.aboutcircles.com/profiles/".to_string(),
+    v1_hub_address: address!("29b9a7fbb8995b2423a71cc17cf9810798f6c543"),
+    v2_hub_address: address!("c12c1e50abb450d6205ea2c3fa861b3b834d13e8"),
+    name_registry_address: address!("a27566fd89162cc3d40cb59c87aaaa49b85f3474"),
+    base_group_mint_policy: address!("cca27c26cf7bac2a9928f42201d48220f0e3a549"),
+    standard_treasury: address!("08f90ab73a515308f03a718257ff9887ed330c6e"),
+    core_members_group_deployer: address!("feca40eb02fb1f4f5f795fc7a03c1a27819b1ded"),
+    base_group_factory_address: address!("d0b5bd9962197beac4cba24244ec3587f19bd06d"),
+    lift_erc20_address: address!("5f99a795dd2743c36d63511f0d4bc667e6d3cdb5"),
+    invitation_escrow_address: address!("8f8b74fa13eaaff4176d061a0f98ad5c8e19c903"),
+    invitation_farm_address: address!("0000000000000000000000000000000000000000"),
+    referrals_module_address: address!("d6df7cc2c2db03ec91761f4469d8dbaac7e538c9"),
+});
+
+/// Convenience helper to retrieve a cloned mainnet config.
+pub fn gnosis_mainnet() -> CirclesConfig {
+    GNOSIS_MAINNET.clone()
+}

--- a/crates/sdk/src/core.rs
+++ b/crates/sdk/src/core.rs
@@ -1,0 +1,73 @@
+use abis::{
+    BaseGroup, BaseGroupFactory, DemurrageCircles, HubV2, InflationaryCircles, InvitationEscrow,
+    InvitationFarm, LiftERC20, NameRegistry, ReferralsModule,
+};
+use alloy_provider::{Identity, ProviderBuilder, RootProvider};
+use circles_types::CirclesConfig;
+
+/// Core contract bundle for the Circles SDK.
+#[derive(Clone)]
+pub struct Core {
+    pub config: CirclesConfig,
+}
+
+impl Core {
+    pub fn new(config: CirclesConfig) -> Self {
+        Self { config }
+    }
+
+    /// HTTP provider built from the configured Circles RPC URL.
+    pub fn provider(&self) -> RootProvider {
+        ProviderBuilder::<Identity, Identity>::default().connect_http(
+            self.config
+                .circles_rpc_url
+                .parse()
+                .expect("circles_rpc_url must be a valid URL"),
+        )
+    }
+
+    pub fn hub_v2(&self) -> HubV2::HubV2Instance<RootProvider> {
+        HubV2::new(self.config.v2_hub_address, self.provider())
+    }
+
+    pub fn name_registry(&self) -> NameRegistry::NameRegistryInstance<RootProvider> {
+        NameRegistry::new(self.config.name_registry_address, self.provider())
+    }
+
+    pub fn base_group_factory(&self) -> BaseGroupFactory::BaseGroupFactoryInstance<RootProvider> {
+        BaseGroupFactory::new(self.config.base_group_factory_address, self.provider())
+    }
+
+    pub fn base_group(
+        &self,
+        address: alloy_primitives::Address,
+    ) -> BaseGroup::BaseGroupInstance<RootProvider> {
+        BaseGroup::new(address, self.provider())
+    }
+
+    pub fn invitation_escrow(&self) -> InvitationEscrow::InvitationEscrowInstance<RootProvider> {
+        InvitationEscrow::new(self.config.invitation_escrow_address, self.provider())
+    }
+
+    pub fn invitation_farm(&self) -> InvitationFarm::InvitationFarmInstance<RootProvider> {
+        InvitationFarm::new(self.config.invitation_farm_address, self.provider())
+    }
+
+    pub fn lift_erc20(&self) -> LiftERC20::LiftERC20Instance<RootProvider> {
+        LiftERC20::new(self.config.lift_erc20_address, self.provider())
+    }
+
+    pub fn demurrage_circles(&self) -> DemurrageCircles::DemurrageCirclesInstance<RootProvider> {
+        DemurrageCircles::new(self.config.v2_hub_address, self.provider())
+    }
+
+    pub fn inflationary_circles(
+        &self,
+    ) -> InflationaryCircles::InflationaryCirclesInstance<RootProvider> {
+        InflationaryCircles::new(self.config.v2_hub_address, self.provider())
+    }
+
+    pub fn referrals_module(&self) -> ReferralsModule::ReferralsModuleInstance<RootProvider> {
+        ReferralsModule::new(self.config.referrals_module_address, self.provider())
+    }
+}

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -259,6 +259,7 @@ impl Sdk {
     }
 
     /// Register a base group via the factory. Returns submitted txs and best-effort avatar.
+    #[allow(clippy::too_many_arguments)]
     pub async fn register_group(
         &self,
         owner: Address,

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,0 +1,291 @@
+//! Circles SDK (Rust) — orchestrates RPC, profiles, and contract interactions.
+//! Minimal scaffold mirroring the TypeScript SDK shape with read-only flows first
+//! and write paths gated behind a `ContractRunner`.
+
+mod avatar;
+mod cid_v0_to_digest;
+pub mod config;
+mod core;
+mod runner;
+mod services;
+#[cfg(feature = "ws")]
+pub mod ws;
+pub use services::registration;
+
+#[cfg(feature = "ws")]
+use alloy_json_rpc::RpcSend;
+use alloy_primitives::Address;
+pub use avatar::{BaseGroupAvatar, HumanAvatar, OrganisationAvatar};
+use circles_profiles::{Profile, Profiles};
+use circles_rpc::CirclesRpc;
+#[cfg(feature = "ws")]
+use circles_rpc::events::subscription::CirclesSubscription;
+#[cfg(feature = "ws")]
+use circles_types::CirclesEvent;
+use circles_types::{AvatarInfo, AvatarType, CirclesConfig, TokenBalanceResponse, TrustRelation};
+use core::Core;
+pub use runner::{ContractRunner, PreparedTransaction, RunnerError, SubmittedTx, call_to_tx};
+#[cfg(feature = "ws")]
+use serde_json::to_value;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Generic registration outcome carrying submitted transactions and an optional avatar.
+pub struct RegistrationResult<T> {
+    pub avatar: Option<T>,
+    pub txs: Vec<SubmittedTx>,
+}
+
+/// High-level SDK errors.
+#[derive(Debug, Error)]
+pub enum SdkError {
+    #[error("circles rpc error: {0}")]
+    Rpc(#[from] circles_rpc::CirclesRpcError),
+    #[error("profiles error: {0}")]
+    Profiles(#[from] circles_profiles::ProfilesError),
+    #[error("transfers error: {0}")]
+    Transfers(#[from] circles_transfers::TransferError),
+    #[error("runner error: {0}")]
+    Runner(#[from] RunnerError),
+    #[error("cid error: {0}")]
+    Cid(#[from] cid_v0_to_digest::CidError),
+    #[error("contract runner is required for this operation")]
+    MissingRunner,
+    #[error("sender address is required for this operation")]
+    MissingSender,
+    #[error("avatar not found for address {0:?}")]
+    AvatarNotFound(Address),
+    #[error("invalid registration input: {0}")]
+    InvalidRegistration(String),
+    #[error("websocket subscription failed after {attempts} attempts: {reason}")]
+    WsSubscribeFailed { attempts: usize, reason: String },
+}
+
+/// Top-level SDK orchestrator.
+pub struct Sdk {
+    pub(crate) config: CirclesConfig,
+    pub(crate) rpc: Arc<CirclesRpc>,
+    pub(crate) profiles: Profiles,
+    pub(crate) core: Arc<Core>,
+    pub(crate) runner: Option<Arc<dyn ContractRunner>>,
+    pub(crate) sender_address: Option<Address>,
+}
+
+impl Sdk {
+    /// Create a new SDK instance. Provide a runner for write operations; omit for read-only.
+    pub fn new(
+        config: CirclesConfig,
+        runner: Option<Arc<dyn ContractRunner>>,
+    ) -> Result<Self, SdkError> {
+        let sender_address = runner.as_ref().map(|r| r.sender_address());
+        let core = Arc::new(Core::new(config.clone()));
+        let rpc = Arc::new(CirclesRpc::try_from_http(&config.circles_rpc_url)?);
+        let profiles = Profiles::new(config.profile_service_url.clone())?;
+        Ok(Self {
+            rpc,
+            profiles,
+            config,
+            core,
+            runner,
+            sender_address,
+        })
+    }
+
+    /// Access the underlying RPC client.
+    pub fn rpc(&self) -> &CirclesRpc {
+        self.rpc.as_ref()
+    }
+
+    /// Access the loaded configuration.
+    pub fn config(&self) -> &CirclesConfig {
+        &self.config
+    }
+
+    /// Access core contract bundle.
+    pub fn core(&self) -> &Arc<Core> {
+        &self.core
+    }
+
+    /// Access the profiles client.
+    pub fn profiles(&self) -> &Profiles {
+        &self.profiles
+    }
+
+    /// Optional runner.
+    pub fn runner(&self) -> Option<&Arc<dyn ContractRunner>> {
+        self.runner.as_ref()
+    }
+
+    /// Sender address derived from the runner.
+    pub fn sender_address(&self) -> Option<Address> {
+        self.sender_address
+    }
+
+    /// Create and pin a profile via the profile service.
+    pub async fn create_profile(&self, profile: &Profile) -> Result<String, SdkError> {
+        Ok(self.profiles.create(profile).await?)
+    }
+
+    /// Fetch a profile by CID (returns `Ok(None)` if missing or unparsable).
+    pub async fn get_profile(&self, cid: &str) -> Result<Option<Profile>, SdkError> {
+        Ok(self.profiles.get(cid).await?)
+    }
+
+    /// Basic data helpers (read-only).
+    pub async fn data_avatar(&self, avatar: Address) -> Result<AvatarInfo, SdkError> {
+        Ok(self.rpc.avatar().get_avatar_info(avatar).await?)
+    }
+
+    pub async fn data_trust(&self, avatar: Address) -> Result<Vec<TrustRelation>, SdkError> {
+        Ok(self.rpc.trust().get_trust_relations(avatar).await?)
+    }
+
+    pub async fn data_balances(
+        &self,
+        avatar: Address,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        Ok(self
+            .rpc
+            .token()
+            .get_token_balances(avatar, as_time_circles, use_v2)
+            .await?)
+    }
+
+    /// Convenience accessor for avatar info (read-only).
+    pub async fn avatar_info(&self, avatar: Address) -> Result<AvatarInfo, SdkError> {
+        Ok(self.rpc.avatar().get_avatar_info(avatar).await?)
+    }
+
+    /// Subscribe to Circles events over websocket with a custom filter.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws<F>(
+        &self,
+        ws_url: &str,
+        filter: F,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError>
+    where
+        F: RpcSend + 'static,
+    {
+        let val = to_value(&filter).map_err(|e| SdkError::WsSubscribeFailed {
+            attempts: 0,
+            reason: e.to_string(),
+        })?;
+        self.subscribe_events_ws_with_retries(ws_url, val, None)
+            .await
+    }
+
+    /// Subscribe with retry/backoff on websocket disconnects.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_retries(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+    ) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+        ws::subscribe_with_retries(ws_url, filter, max_attempts).await
+    }
+
+    /// Subscribe with retry/backoff and optional HTTP catch-up.
+    #[cfg(feature = "ws")]
+    pub async fn subscribe_events_ws_with_catchup(
+        &self,
+        ws_url: &str,
+        filter: serde_json::Value,
+        max_attempts: Option<usize>,
+        catch_up_from_block: Option<u64>,
+        catch_up_filter: Option<Vec<circles_types::Filter>>,
+    ) -> Result<(Vec<CirclesEvent>, CirclesSubscription<CirclesEvent>), SdkError> {
+        ws::subscribe_with_catchup(
+            self.rpc.as_ref(),
+            ws_url,
+            filter,
+            max_attempts,
+            catch_up_from_block,
+            catch_up_filter,
+            None,
+        )
+        .await
+    }
+
+    /// Fetch avatar info and return a typed avatar wrapper.
+    pub async fn get_avatar(&self, avatar: Address) -> Result<Avatar, SdkError> {
+        let info = self.rpc.avatar().get_avatar_info(avatar).await?;
+        Ok(match info.avatar_type {
+            AvatarType::CrcV2RegisterGroup => Avatar::Group(BaseGroupAvatar::new(
+                avatar,
+                info,
+                self.core.clone(),
+                self.profiles.clone(),
+                self.rpc.clone(),
+                self.runner.clone(),
+            )),
+            AvatarType::CrcV2RegisterOrganization => Avatar::Organisation(OrganisationAvatar::new(
+                avatar,
+                info,
+                self.core.clone(),
+                self.profiles.clone(),
+                self.rpc.clone(),
+                self.runner.clone(),
+            )),
+            _ => Avatar::Human(HumanAvatar::new(
+                avatar,
+                info,
+                self.core.clone(),
+                self.profiles.clone(),
+                self.rpc.clone(),
+                self.runner.clone(),
+            )),
+        })
+    }
+
+    /// Register a human avatar (profile is pinned before submission). Requires a runner.
+    pub async fn register_human(
+        &self,
+        inviter: Address,
+        profile: &Profile,
+    ) -> Result<RegistrationResult<HumanAvatar>, SdkError> {
+        registration::register_human(self, inviter, profile).await
+    }
+
+    /// Register an organisation avatar. Requires a runner.
+    pub async fn register_organisation(
+        &self,
+        name: &str,
+        profile: &Profile,
+    ) -> Result<RegistrationResult<OrganisationAvatar>, SdkError> {
+        registration::register_organisation(self, name, profile).await
+    }
+
+    /// Register a base group via the factory. Returns submitted txs and best-effort avatar.
+    pub async fn register_group(
+        &self,
+        owner: Address,
+        service: Address,
+        fee_collection: Address,
+        initial_conditions: &[Address],
+        name: &str,
+        symbol: &str,
+        profile: &Profile,
+    ) -> Result<RegistrationResult<BaseGroupAvatar>, SdkError> {
+        registration::register_group(
+            self,
+            owner,
+            service,
+            fee_collection,
+            initial_conditions,
+            name,
+            symbol,
+            profile,
+        )
+        .await
+    }
+}
+
+/// Top-level avatar enum (human, organisation, group).
+pub enum Avatar {
+    Human(HumanAvatar),
+    Organisation(OrganisationAvatar),
+    Group(BaseGroupAvatar),
+}

--- a/crates/sdk/src/runner.rs
+++ b/crates/sdk/src/runner.rs
@@ -1,0 +1,50 @@
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_sol_types::SolCall;
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Prepared transaction for a runner to submit. This is intentionally simple;
+/// we can swap to richer contract-specific types as we wire more flows.
+#[derive(Debug, Clone)]
+pub struct PreparedTransaction {
+    pub to: Address,
+    pub data: Bytes,
+    pub value: Option<U256>,
+}
+
+/// Helper to turn a SolCall into a prepared transaction.
+pub fn call_to_tx<C: SolCall>(to: Address, call: C, value: Option<U256>) -> PreparedTransaction {
+    PreparedTransaction {
+        to,
+        data: Bytes::from(call.abi_encode()),
+        value,
+    }
+}
+
+/// Result stub for submitted transactions. Will be expanded when wiring a Safe runner.
+#[derive(Debug, Clone)]
+pub struct SubmittedTx {
+    pub tx_hash: Bytes,
+}
+
+/// Trait that allows the SDK to send transactions (e.g., via a Safe).
+#[async_trait]
+pub trait ContractRunner: Send + Sync {
+    /// Address of the sender/safe/owner associated with this runner.
+    fn sender_address(&self) -> Address;
+
+    /// Submit one or more prepared transactions.
+    async fn send_transactions(
+        &self,
+        txs: Vec<PreparedTransaction>,
+    ) -> Result<Vec<SubmittedTx>, RunnerError>;
+}
+
+/// Errors surfaced by the runner.
+#[derive(Debug, Error)]
+pub enum RunnerError {
+    #[error("runner refused to send transactions: {0}")]
+    Rejected(String),
+    #[error("runner transport error: {0}")]
+    Transport(String),
+}

--- a/crates/sdk/src/services/mod.rs
+++ b/crates/sdk/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod registration;

--- a/crates/sdk/src/services/registration.rs
+++ b/crates/sdk/src/services/registration.rs
@@ -1,0 +1,191 @@
+use crate::avatar::{BaseGroupAvatar, HumanAvatar, OrganisationAvatar};
+use crate::cid_v0_to_digest::cid_v0_to_digest;
+use crate::{RegistrationResult, Sdk, SdkError, call_to_tx};
+use abis::{BaseGroupFactory, HubV2};
+use alloy_primitives::{Address, U256};
+use circles_profiles::Profile;
+use circles_types::AvatarInfo;
+
+pub async fn register_human(
+    sdk: &Sdk,
+    inviter: Address,
+    profile: &Profile,
+) -> Result<RegistrationResult<HumanAvatar>, SdkError> {
+    let runner = sdk.runner.clone().ok_or(SdkError::MissingRunner)?;
+    let sender = sdk.sender_address.ok_or(SdkError::MissingSender)?;
+
+    // Check invitation escrow for pending invites; redeem first if present.
+    let inviters = sdk
+        .core
+        .invitation_escrow()
+        .getInviters(sender)
+        .call()
+        .await
+        .unwrap_or_default();
+
+    let mut txs = Vec::new();
+    if let Some(first_inviter) = inviters.first() {
+        let redeem = abis::InvitationEscrow::redeemInvitationCall {
+            inviter: *first_inviter,
+        };
+        txs.push(call_to_tx(
+            sdk.config.invitation_escrow_address,
+            redeem,
+            None,
+        ));
+    } else {
+        // No pending invites; ensure inviter has at least 96 CRC.
+        let token_id = sdk
+            .core
+            .hub_v2()
+            .toTokenId(inviter)
+            .call()
+            .await
+            .map_err(|e| SdkError::InvalidRegistration(e.to_string()))?;
+        let balance = sdk
+            .core
+            .hub_v2()
+            .balanceOf(inviter, token_id)
+            .call()
+            .await
+            .map_err(|e| SdkError::InvalidRegistration(e.to_string()))?;
+        let min_required = U256::from(96u128) * U256::from(10).pow(U256::from(18));
+        if balance < min_required {
+            return Err(SdkError::InvalidRegistration(
+                "inviter has insufficient balance (requires 96 CRC)".to_string(),
+            ));
+        }
+    }
+
+    let cid = sdk.profiles.create(profile).await?;
+    let digest = cid_v0_to_digest(&cid)?;
+    let call = HubV2::registerHumanCall {
+        _inviter: inviter,
+        _metadataDigest: digest,
+    };
+    txs.push(call_to_tx(sdk.config.v2_hub_address, call, None));
+    let sent = runner.send_transactions(txs).await?;
+    let info = sdk.rpc.avatar().get_avatar_info(sender).await?;
+    let avatar = HumanAvatar::new(
+        sender,
+        info,
+        sdk.core.clone(),
+        sdk.profiles.clone(),
+        sdk.rpc.clone(),
+        sdk.runner.clone(),
+    );
+    Ok(RegistrationResult {
+        avatar: Some(avatar),
+        txs: sent,
+    })
+}
+
+pub async fn register_organisation(
+    sdk: &Sdk,
+    name: &str,
+    profile: &Profile,
+) -> Result<RegistrationResult<OrganisationAvatar>, SdkError> {
+    if name.is_empty() {
+        return Err(SdkError::InvalidRegistration(
+            "organisation name cannot be empty".to_string(),
+        ));
+    }
+    let runner = sdk.runner.clone().ok_or(SdkError::MissingRunner)?;
+    let sender = sdk.sender_address.ok_or(SdkError::MissingSender)?;
+
+    let cid = sdk.profiles.create(profile).await?;
+    let digest = cid_v0_to_digest(&cid)?;
+    let call = HubV2::registerOrganizationCall {
+        _name: name.to_string(),
+        _metadataDigest: digest,
+    };
+    let txs = vec![call_to_tx(sdk.config.v2_hub_address, call, None)];
+    let sent = runner.send_transactions(txs).await?;
+    let info = sdk.rpc.avatar().get_avatar_info(sender).await?;
+    let avatar = OrganisationAvatar::new(
+        sender,
+        info,
+        sdk.core.clone(),
+        sdk.profiles.clone(),
+        sdk.rpc.clone(),
+        sdk.runner.clone(),
+    );
+    Ok(RegistrationResult {
+        avatar: Some(avatar),
+        txs: sent,
+    })
+}
+
+pub async fn register_group(
+    sdk: &Sdk,
+    owner: Address,
+    service: Address,
+    fee_collection: Address,
+    initial_conditions: &[Address],
+    name: &str,
+    symbol: &str,
+    profile: &Profile,
+) -> Result<RegistrationResult<BaseGroupAvatar>, SdkError> {
+    if name.is_empty() || name.len() > 19 {
+        return Err(SdkError::InvalidRegistration(
+            "group name must be 1–19 chars".to_string(),
+        ));
+    }
+    if symbol.is_empty() {
+        return Err(SdkError::InvalidRegistration(
+            "group symbol cannot be empty".to_string(),
+        ));
+    }
+
+    let runner = sdk.runner.clone().ok_or(SdkError::MissingRunner)?;
+
+    let cid = sdk.profiles.create(profile).await?;
+    let digest = cid_v0_to_digest(&cid)?;
+    let call = BaseGroupFactory::createBaseGroupCall {
+        _owner: owner,
+        _service: service,
+        _feeCollection: fee_collection,
+        _initialConditions: initial_conditions.to_vec(),
+        _name: name.to_string(),
+        _symbol: symbol.to_string(),
+        _metadataDigest: digest,
+    };
+    let txs = vec![call_to_tx(
+        sdk.config.base_group_factory_address,
+        call,
+        None,
+    )];
+    let predicted = sdk
+        .core
+        .base_group_factory()
+        .createBaseGroup(
+            owner,
+            service,
+            fee_collection,
+            initial_conditions.to_vec(),
+            name.to_string(),
+            symbol.to_string(),
+            digest,
+        )
+        .call()
+        .await
+        .ok();
+
+    let sent = runner.send_transactions(txs).await?;
+
+    let avatar = if let Some(predicted) = predicted {
+        let info: AvatarInfo = sdk.rpc.avatar().get_avatar_info(predicted.group).await?;
+        Some(BaseGroupAvatar::new(
+            predicted.group,
+            info,
+            sdk.core.clone(),
+            sdk.profiles.clone(),
+            sdk.rpc.clone(),
+            sdk.runner.clone(),
+        ))
+    } else {
+        None
+    };
+
+    Ok(RegistrationResult { avatar, txs: sent })
+}

--- a/crates/sdk/src/services/registration.rs
+++ b/crates/sdk/src/services/registration.rs
@@ -116,6 +116,7 @@ pub async fn register_organisation(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn register_group(
     sdk: &Sdk,
     owner: Address,

--- a/crates/sdk/src/ws.rs
+++ b/crates/sdk/src/ws.rs
@@ -1,0 +1,90 @@
+use crate::SdkError;
+use circles_rpc::{CirclesRpc, events::subscription::CirclesSubscription};
+use circles_types::{CirclesEvent, Filter};
+use futures::StreamExt;
+use serde_json::Value;
+use tokio::time::sleep;
+use tracing::warn;
+
+/// Subscribe with retry/backoff on websocket disconnects.
+pub async fn subscribe_with_retries(
+    ws_url: &str,
+    filter: Value,
+    max_attempts: Option<usize>,
+) -> Result<CirclesSubscription<CirclesEvent>, SdkError> {
+    let mut attempt = 0usize;
+    let cap = max_attempts.unwrap_or(5);
+    loop {
+        attempt += 1;
+        let ws = match CirclesRpc::try_from_ws(ws_url).await {
+            Ok(ws) => ws,
+            Err(_err) if attempt < cap => {
+                let delay_ms = (1u64 << attempt).saturating_mul(1000).min(10_000);
+                sleep(std::time::Duration::from_millis(delay_ms)).await;
+                continue;
+            }
+            Err(err) => {
+                return Err(SdkError::WsSubscribeFailed {
+                    attempts: attempt,
+                    reason: err.to_string(),
+                });
+            }
+        };
+        let sub_res = ws.events().subscribe_parsed_events(filter.clone()).await;
+        match sub_res {
+            Ok(sub) => return Ok(sub),
+            Err(_err) if attempt < cap => {
+                let delay_ms = (1u64 << attempt).saturating_mul(1000).min(10_000);
+                sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            Err(err) => {
+                return Err(SdkError::WsSubscribeFailed {
+                    attempts: attempt,
+                    reason: err.to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// Fetch historical events (HTTP) then subscribe live (WS).
+pub async fn subscribe_with_catchup(
+    rpc: &CirclesRpc,
+    ws_url: &str,
+    filter: Value,
+    max_attempts: Option<usize>,
+    catch_up_from_block: Option<u64>,
+    catch_up_filter: Option<Vec<Filter>>,
+    address: Option<circles_types::Address>,
+) -> Result<(Vec<CirclesEvent>, CirclesSubscription<CirclesEvent>), SdkError> {
+    let catch_up_events = if let Some(from_block) = catch_up_from_block {
+        rpc.events()
+            .circles_events(address, from_block, None, catch_up_filter)
+            .await?
+    } else {
+        Vec::new()
+    };
+    let sub = subscribe_with_retries(ws_url, filter, max_attempts).await?;
+    Ok((catch_up_events, sub))
+}
+
+/// Spawn a handler over a subscription; errors are logged via tracing at warn.
+pub fn spawn_event_handler<H>(
+    mut sub: CirclesSubscription<CirclesEvent>,
+    handler: H,
+) -> tokio::task::JoinHandle<()>
+where
+    H: Fn(CirclesEvent) + Send + Sync + 'static,
+{
+    let handler = std::sync::Arc::new(handler);
+    tokio::spawn(async move {
+        while let Some(item) = sub.next().await {
+            match item {
+                Ok(evt) => handler(evt),
+                Err(err) => {
+                    warn!(error = %err, "ws event stream error");
+                }
+            }
+        }
+    })
+}

--- a/crates/sdk/tests/common.rs
+++ b/crates/sdk/tests/common.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+use alloy_primitives::Address;
+use circles_sdk::config;
+use circles_types::CirclesConfig;
+
+fn live_enabled() -> bool {
+    std::env::var("RUN_LIVE").as_deref() == Ok("1")
+}
+
+/// Returns a live config if `RUN_LIVE=1`, applying env overrides when set.
+pub fn maybe_live_config() -> Option<CirclesConfig> {
+    if !live_enabled() {
+        return None;
+    }
+    let mut cfg = config::gnosis_mainnet();
+    if let Ok(url) = std::env::var("CIRCLES_RPC_URL") {
+        cfg.circles_rpc_url = url;
+    }
+    if let Ok(url) = std::env::var("CIRCLES_PATHFINDER_URL") {
+        cfg.pathfinder_url = url;
+    }
+    if let Ok(url) = std::env::var("CIRCLES_PROFILE_URL") {
+        cfg.profile_service_url = url;
+    }
+    Some(cfg)
+}
+
+/// Reads `LIVE_AVATAR` as a hex address when `RUN_LIVE=1`.
+pub fn maybe_live_avatar() -> Option<Address> {
+    if !live_enabled() {
+        return None;
+    }
+    let addr = std::env::var("LIVE_AVATAR").ok()?;
+    Address::from_str(addr.as_str()).ok()
+}

--- a/crates/sdk/tests/live_pathfind.rs
+++ b/crates/sdk/tests/live_pathfind.rs
@@ -95,7 +95,7 @@ async fn live_max_flow_to_targets() -> Result<(), Box<dyn std::error::Error>> {
                     println!("max_flow to {:#x}: {}", target, res.max_flow);
                 }
                 Err(err) => {
-                    eprintln!("max_flow_to {:#x} failed: {err}", target);
+                    eprintln!("max_flow_to {target:#x} failed: {err}");
                 }
             }
         }

--- a/crates/sdk/tests/live_pathfind.rs
+++ b/crates/sdk/tests/live_pathfind.rs
@@ -1,0 +1,146 @@
+mod common;
+
+use circles_sdk::Sdk;
+use circles_types::AdvancedTransferOptions;
+use std::str::FromStr;
+
+#[tokio::test]
+#[ignore]
+async fn live_max_flow_self() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(cfg) = common::maybe_live_config() else {
+        eprintln!("skipping live test: set RUN_LIVE=1");
+        return Ok(());
+    };
+    let Some(addr) = common::maybe_live_avatar() else {
+        eprintln!("skipping live test: set LIVE_AVATAR=0x...");
+        return Ok(());
+    };
+
+    let sdk = Sdk::new(cfg, None)?;
+    let avatar = sdk.get_avatar(addr).await?;
+
+    // Self-to-self max flow is a safe read; options use wrapped balances by default.
+    let options = AdvancedTransferOptions {
+        use_wrapped_balances: Some(true),
+        from_tokens: None,
+        to_tokens: None,
+        exclude_from_tokens: None,
+        exclude_to_tokens: None,
+        simulated_balances: None,
+        max_transfers: None,
+        tx_data: None,
+    };
+
+    if let circles_sdk::Avatar::Human(h) = avatar {
+        let res = h.max_flow_to(addr, Some(options)).await?;
+        println!("max_flow to self: {}", res.max_flow);
+    } else {
+        eprintln!("skipping: avatar is not human, cannot pathfind self");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_max_flow_to_targets() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(cfg) = common::maybe_live_config() else {
+        eprintln!("skipping live test: set RUN_LIVE=1");
+        return Ok(());
+    };
+    let Some(addr) = common::maybe_live_avatar() else {
+        eprintln!("skipping live test: set LIVE_AVATAR=0x...");
+        return Ok(());
+    };
+
+    // Use env-provided targets if set, otherwise a baked-in list of active avatars.
+    let targets: Vec<_> = std::env::var("LIVE_TARGETS")
+        .ok()
+        .and_then(|csv| {
+            let parsed: Vec<_> = csv
+                .split(',')
+                .filter_map(|s| circles_types::Address::from_str(s.trim()).ok())
+                .collect();
+            if parsed.is_empty() {
+                None
+            } else {
+                Some(parsed)
+            }
+        })
+        .unwrap_or_else(|| {
+            [
+                "0xbf4d332242049ebf71da676ac5fa01a74121dc0d",
+                "0x96821a4f2e986729759a146abedceacba690351c",
+                "0xd447bdea939313c2e83654be3220e87fd0d7bdf6",
+                "0x9c4722d5d93e721db31afffb0dcb6938fe0d9f8e",
+                "0xa65d69e34da7ffcb45804aa437b1f4c9fedeaef7",
+                "0xede0c2e70e8e2d54609c1bdf79595506b6f623fe",
+                "0x6b69683c8897e3d18e74b1ba117b49f80423da5d",
+                "0xf48554937f18885c7f15c432c596b5843648231d",
+            ]
+            .iter()
+            .filter_map(|s| circles_types::Address::from_str(s).ok())
+            .collect()
+        });
+
+    let sdk = Sdk::new(cfg, None)?;
+    let avatar = sdk.get_avatar(addr).await?;
+
+    if let circles_sdk::Avatar::Human(h) = avatar {
+        let mut successes = 0usize;
+        for target in targets {
+            match h.max_flow_to(target, None).await {
+                Ok(res) => {
+                    successes += 1;
+                    println!("max_flow to {:#x}: {}", target, res.max_flow);
+                }
+                Err(err) => {
+                    eprintln!("max_flow_to {:#x} failed: {err}", target);
+                }
+            }
+        }
+        if successes == 0 {
+            eprintln!("no max_flow_to targets succeeded; check trust graph or targets");
+        }
+    } else {
+        eprintln!("skipping: avatar is not human, cannot pathfind");
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn live_plan_transfer_self_zero() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(cfg) = common::maybe_live_config() else {
+        eprintln!("skipping live test: set RUN_LIVE=1");
+        return Ok(());
+    };
+    let Some(addr) = common::maybe_live_avatar() else {
+        eprintln!("skipping live test: set LIVE_AVATAR=0x...");
+        return Ok(());
+    };
+
+    let sdk = Sdk::new(cfg, None)?;
+    let avatar = sdk.get_avatar(addr).await?;
+
+    if let circles_sdk::Avatar::Human(h) = avatar {
+        // zero transfer planning may return NoPathFound; tolerate that
+        match h
+            .plan_transfer(addr, alloy_primitives::U256::from(0u64), None)
+            .await
+        {
+            Ok(txs) => assert!(txs.is_empty(), "expected no txs for zero transfer"),
+            Err(circles_sdk::SdkError::Transfers(
+                circles_transfers::TransferError::NoPathFound { .. },
+            )) => {
+                eprintln!("no path found for zero transfer; tolerated");
+            }
+            Err(err) => return Err(err.into()),
+        }
+    } else {
+        eprintln!("skipping: avatar is not human, cannot plan transfer");
+    }
+
+    Ok(())
+}

--- a/crates/sdk/tests/live_read.rs
+++ b/crates/sdk/tests/live_read.rs
@@ -1,0 +1,20 @@
+mod common;
+
+use circles_sdk::Sdk;
+
+#[tokio::test]
+#[ignore]
+async fn live_avatar_info_reads() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(cfg) = common::maybe_live_config() else {
+        eprintln!("skipping live test: set RUN_LIVE=1");
+        return Ok(());
+    };
+    let Some(addr) = common::maybe_live_avatar() else {
+        eprintln!("skipping live test: set LIVE_AVATAR=0x...");
+        return Ok(());
+    };
+    let sdk = Sdk::new(cfg, None)?;
+    let info = sdk.avatar_info(addr).await?;
+    assert_eq!(info.avatar, addr);
+    Ok(())
+}

--- a/crates/sdk/tests/pathfind_transfer.rs
+++ b/crates/sdk/tests/pathfind_transfer.rs
@@ -1,0 +1,29 @@
+use alloy_primitives::U256;
+use alloy_primitives::address;
+use circles_types::AdvancedTransferOptions;
+
+#[test]
+fn advanced_options_to_find_path_params() {
+    let opts = AdvancedTransferOptions {
+        use_wrapped_balances: Some(false),
+        from_tokens: Some(vec![address!("1000000000000000000000000000000000000001")]),
+        to_tokens: Some(vec![address!("2000000000000000000000000000000000000002")]),
+        exclude_from_tokens: Some(vec![address!("3000000000000000000000000000000000000003")]),
+        exclude_to_tokens: Some(vec![address!("4000000000000000000000000000000000000004")]),
+        simulated_balances: None,
+        max_transfers: Some(5),
+        tx_data: None,
+    };
+    let params = opts.to_find_path_params(
+        address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        address!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        U256::from(123u64),
+    );
+    assert_eq!(params.use_wrapped_balances, Some(false));
+    assert_eq!(
+        params.from_tokens.unwrap()[0],
+        address!("1000000000000000000000000000000000000001")
+    );
+    assert_eq!(params.max_transfers, Some(5));
+    assert_eq!(params.target_flow, U256::from(123u64));
+}

--- a/crates/sdk/tests/registration_invites.rs
+++ b/crates/sdk/tests/registration_invites.rs
@@ -1,0 +1,53 @@
+use alloy_primitives::{Address, TxHash};
+use circles_types::{AvatarInfo, AvatarType, CirclesConfig};
+
+fn dummy_config() -> CirclesConfig {
+    CirclesConfig {
+        circles_rpc_url: "https://rpc.example.com".into(),
+        pathfinder_url: "".into(),
+        profile_service_url: "https://profiles.example.com".into(),
+        v1_hub_address: Address::ZERO,
+        v2_hub_address: Address::ZERO,
+        name_registry_address: Address::ZERO,
+        base_group_mint_policy: Address::ZERO,
+        standard_treasury: Address::ZERO,
+        core_members_group_deployer: Address::ZERO,
+        base_group_factory_address: Address::ZERO,
+        lift_erc20_address: Address::ZERO,
+        invitation_escrow_address: Address::ZERO,
+        invitation_farm_address: Address::ZERO,
+        referrals_module_address: Address::ZERO,
+    }
+}
+
+fn dummy_avatar(address: Address) -> AvatarInfo {
+    AvatarInfo {
+        block_number: 0,
+        timestamp: None,
+        transaction_index: 0,
+        log_index: 0,
+        transaction_hash: TxHash::ZERO,
+        version: 2,
+        avatar_type: AvatarType::CrcV2RegisterHuman,
+        avatar: address,
+        token_id: None,
+        has_v1: false,
+        v1_token: None,
+        cid_v0_digest: None,
+        cid_v0: None,
+        v1_stopped: None,
+        is_human: true,
+        name: None,
+        symbol: None,
+    }
+}
+
+#[test]
+fn registration_helper_types_compile() {
+    // This test ensures the registration helper path is accessible without running async.
+    // (Full integration would require contract/mocks; this keeps compile-time coverage.)
+    let config = dummy_config();
+    let _info = dummy_avatar(Address::ZERO);
+    // No runtime assertions; compilation is the check.
+    let _ = config;
+}

--- a/crates/types/src/avatar.rs
+++ b/crates/types/src/avatar.rs
@@ -71,6 +71,7 @@ pub struct AvatarInfo {
 
 /// Profile information
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Profile {
     pub name: String,
     pub description: Option<String>,
@@ -87,4 +88,31 @@ pub struct GroupProfile {
     #[serde(flatten)]
     pub profile: Profile,
     pub symbol: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Profile;
+
+    #[test]
+    fn profile_deserializes_camel_case() {
+        let json = r#"{
+            "name": "franco",
+            "previewImageUrl": "data:image/jpeg;base64,abc",
+            "imageUrl": "https://example.com/full.jpg",
+            "location": "Berlin"
+        }"#;
+
+        let profile: Profile = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(profile.name, "franco");
+        assert_eq!(
+            profile.preview_image_url.as_deref(),
+            Some("data:image/jpeg;base64,abc")
+        );
+        assert_eq!(
+            profile.image_url.as_deref(),
+            Some("https://example.com/full.jpg")
+        );
+        assert_eq!(profile.location.as_deref(), Some("Berlin"));
+    }
 }

--- a/crates/types/src/avatar.rs
+++ b/crates/types/src/avatar.rs
@@ -28,15 +28,20 @@ pub struct GeoLocation {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AvatarInfo {
     /// The block number of the event
+    #[serde(default, rename = "blockNumber")]
     pub block_number: u64,
     /// The timestamp of the last change to the avatar
     /// Note: May be undefined for some avatars
+    #[serde(default)]
     pub timestamp: Option<u64>,
     /// The transaction index
+    #[serde(default, rename = "transactionIndex")]
     pub transaction_index: u32,
     /// The log index
+    #[serde(default, rename = "logIndex")]
     pub log_index: u32,
     /// The hash of the transaction that last changed the avatar
+    #[serde(default, rename = "transactionHash")]
     pub transaction_hash: TxHash,
     /// If the avatar is currently active in version 1 or 2
     /// Note: An avatar that's active in v2 can still have a v1 token. See `has_v1` and `v1_token`.
@@ -49,19 +54,26 @@ pub struct AvatarInfo {
     /// The personal or group token address (v1) or tokenId (v2)
     /// Note: v1 tokens are erc20 and have a token address. v2 tokens are erc1155 and have a tokenId.
     ///       The v2 tokenId is always an encoded version of the avatar address.
+    #[serde(rename = "tokenId")]
     pub token_id: Option<U256>,
     /// If the avatar is signed up at v1
+    #[serde(rename = "hasV1")]
     pub has_v1: bool,
     /// If the avatar has a v1 token, this is the token address
+    #[serde(rename = "v1Token")]
     pub v1_token: Option<Address>,
     /// The bytes of the avatar's metadata cidv0
+    #[serde(rename = "cidV0Digest")]
     pub cid_v0_digest: Option<String>,
     /// The CIDv0 of the avatar's metadata (profile)
+    #[serde(rename = "cidV0")]
     pub cid_v0: Option<String>,
     /// If the avatar is stopped in v1
     /// Note: This is only set during Avatar initialization.
+    #[serde(rename = "v1Stopped")]
     pub v1_stopped: Option<bool>,
     /// Indicates whether the entity is a human
+    #[serde(rename = "isHuman")]
     pub is_human: bool,
     /// Groups have a name
     pub name: Option<String>,


### PR DESCRIPTION
- Scaffold `circles-sdk` crate and modularize avatars (human/org/group/common), core wiring, runner traits/tx helpers, WS utilities, and registration services; add CIDv0 digest conversion.
- Implement registration flows (human/org/group), trust/profile parity, invitation/referral helpers, transfer/pathfinding planning integrations, and shared mainnet config (`config::gnosis_mainnet`).
- Add serde defaults/renames to `AvatarInfo` to handle live RPC camelCase/missing fields.
- Provide SDK examples (`basic_read`, `invite_generate`, `ws_subscribe`) with README; add env-gated live integration tests for avatar info and pathfinding/transfer planning (optional `LIVE_TARGETS`, `RUN_LIVE=1`, `LIVE_AVATAR=...`).

**Testing:**
- `cargo test -p circles-sdk`
- `cargo check -p circles-sdk --examples --features ws`
- Live (opt-in): 
```bash
RUN_LIVE=1 LIVE_AVATAR=0xcf6dc192dc292d5f2789da2db02d6dd4f41f4214 cargo test \
  -p circles-sdk -- --ignored live_avatar_info_reads live_max_flow_to_targets
```