### PR TITLE
feat: continue pathfinder and transfer parity work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,24 @@ members = [
 [workspace.dependencies]
 # Shared dependencies across all crates
 alloy-contract = "1.1.2"
+alloy-json-abi = "1.4.1"
 alloy-json-rpc = "1.1.2"
 alloy-provider = { version = "1.1.2", features = ["reqwest"] }
 alloy-primitives = { version = "1.4.1", default-features = false, features = [
     "serde",
 ] }
+alloy-rpc-types = "1.1.2"
 alloy-sol-types = { version = "1.4.1", features = ["json"] }
+alloy-transport-http = "1.1.2"
+alloy-transport-ws = "1.1.2"
 async-trait = "0.1.89"
+circles-abis = { path = "crates/abis", version = "0.1.0" }
+circles-pathfinder = { path = "crates/pathfinder", version = "0.5.0" }
+circles-profiles = { path = "crates/profiles", version = "0.1.0" }
+circles-rpc = { path = "crates/rpc", version = "0.1.0" }
+circles-transfers = { path = "crates/transfers", version = "0.1.0" }
 circles-types = { path = "crates/types", version = "0.3.0" }
+circles-utils = { path = "crates/utils", version = "0.1.0" }
 futures = "0.3"
 reqwest = { version = "0.12.24", default-features = false, features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ The recommended entrypoint for application code is `circles-sdk`. Lower-level cr
 - [`circles-sdk`](crates/sdk/) — thin orchestrator wiring RPC, profiles, pathfinding, transfers, and optional contract runners; WS helpers with retry/catch-up.
 - [`crates/abis`](crates/abis/) — generated contract bindings.
 
+## TypeScript parity snapshot
+
+As of March 26, 2026, this workspace is closer to the TypeScript SDK, but it is not yet at full feature parity.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place and is already used by the higher-level crates. |
+| `circles-pathfinder` | Close | Recent parity work aligned flow-matrix terminal edges, wrapped-token rewriting, token-info helpers, netted-flow helpers, and explicit RPC/client entrypoints. |
+| `circles-transfers` | Partial | Advanced transfer planning is largely present, including wrapped-token handling and the aggregate transfer path, but the TS `constructReplenish` flow is still missing. |
+| `circles-sdk` | Partial | Read flows and typed avatars are usable; full parity still depends on remaining transfer/replenish coverage and some higher-level convenience surface. |
+| `circles-profiles`, `circles-utils`, `circles-types`, `circles-abis` | Supporting / lower risk | These crates are in service for the current SDK flows and are not the main parity bottlenecks right now. |
+
+The biggest known parity gap today is the replenish flow from the TS transfer builder. If you need exact TS-equivalent behavior for transfer acquisition/top-up flows, validate that path carefully before treating the Rust SDK as a drop-in replacement.
+
 ## Usage model
 
 - Read-only flows work with `Sdk::new(config, None)`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Rust implementation of the Circles SDK: JSON-RPC client, pathfinding/flow matrix tooling, transfer planning, utilities, and a higher-level `circles-sdk` orchestrator. The workspace mirrors the TypeScript SDK shape while leaning on Alloy for Ethereum primitives and transports.
 
+The recommended entrypoint for application code is `circles-sdk`. Lower-level crates remain available when you want direct RPC access, custom pathfinding, or transfer planning without the full orchestrator.
+
 ## Crates at a glance
 - [`circles-rpc`](crates/rpc/) — HTTP/WS JSON-RPC client with pagination helpers and event subscriptions.
 - [`circles-pathfinder`](crates/pathfinder/) — pathfinding + flow matrix utilities (wrapped token handling, netted-flow checks) ready for contract calls.
@@ -12,6 +14,13 @@ Rust implementation of the Circles SDK: JSON-RPC client, pathfinding/flow matrix
 - [`circles-types`](crates/types/) — shared types for RPC responses, events, pathfinding, contracts, and config.
 - [`circles-sdk`](crates/sdk/) — thin orchestrator wiring RPC, profiles, pathfinding, transfers, and optional contract runners; WS helpers with retry/catch-up.
 - [`crates/abis`](crates/abis/) — generated contract bindings.
+
+## Usage model
+
+- Read-only flows work with `Sdk::new(config, None)`.
+- Typed avatar wrappers are discovered at runtime via `Sdk::get_avatar`.
+- Write paths are delegated to a `ContractRunner` implementation instead of being hard-wired to one wallet transport.
+- Lower-level crates can be used directly when you want narrower control over RPC, pathfinding, or transfer assembly.
 
 ## Quick start (read-only SDK)
 ```rust
@@ -28,10 +37,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-## Docs and rustdoc
-- Generate docs: `cargo doc --workspace --all-features` (add `--open` to launch the browser).
-- Crate-level docs use inner `//!` comments; public APIs are documented with `///` per [rustdoc best practices](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html).
-- Browse per-crate READMEs for focused examples and feature notes.
+## Docs
+
+- Generate docs with `cargo doc --workspace --all-features --no-deps`.
+- `crates/sdk/README.md` is the best starting point for application integration.
+- Per-crate READMEs cover focused examples and feature notes.
 
 ## Examples
 - RPC pagination + WS:  
@@ -40,10 +50,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   `cargo run -p circles-pathfinder --example contract_integration`
 - SDK examples: `cargo run -p circles-sdk --example basic_read` (see `crates/sdk/examples/` for invite generation and WS subscribe demos).
 
-## Tests
-- `cargo test -p circles-rpc`
-- `cargo test -p circles-pathfinder`
-- `cargo test -p circles-sdk --features ws -- --ignored` (live RPC/WS, gated by `RUN_LIVE=1` and `LIVE_AVATAR=0x...`; override endpoints with `CIRCLES_RPC_URL`, `CIRCLES_PATHFINDER_URL`, `CIRCLES_PROFILE_URL`)
+## Validation
+
+- `cargo check`
+- `cargo clippy --workspace --all-targets`
+- `cargo test`
+- `cargo doc --workspace --all-features --no-deps`
+
+Live SDK checks remain opt-in:
+
+- `RUN_LIVE=1 LIVE_AVATAR=0x... cargo test -p circles-sdk -- --ignored`
+- Override endpoints with `CIRCLES_RPC_URL`, `CIRCLES_PATHFINDER_URL`, and `CIRCLES_PROFILE_URL`
 
 ## Development
 - Rust 1.75+ and Cargo are required.

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -18,8 +18,8 @@ alloy-primitives = { workspace = true }                                         
 alloy-provider = { workspace = true }
 alloy-sol-types = { workspace = true }                     # sol! macro
 circles-types = { workspace = true }
-circles-rpc = { path = "../rpc", version = "0.1.0" }
-circles-utils = { path = "../utils", version = "0.1.0" }
+circles-rpc = { workspace = true }
+circles-utils = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -23,9 +23,11 @@ circles-utils = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
-futures = { workspace = true }
 
 [features]
 default = []
 ws = ["circles-rpc/ws"]
+
+[dev-dependencies]
+futures = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/pathfinder/examples/path_and_events.rs
+++ b/crates/pathfinder/examples/path_and_events.rs
@@ -15,6 +15,7 @@ use circles_rpc::CirclesRpc;
 use futures::StreamExt;
 
 const DEFAULT_RPC_URL: &str = "https://rpc.aboutcircles.com/";
+#[cfg(feature = "ws")]
 const DEFAULT_WS_URL: &str = "wss://rpc.helsinki.aboutcircles.com/ws";
 // Sample addresses; replace with your own.
 const SAMPLE_FROM: &str = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
@@ -23,6 +24,7 @@ const SAMPLE_TO: &str = "0x6b69683c8897e3d18e74b1ba117b49f80423da5d";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let http_url = std::env::var("CIRCLES_RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_string());
+    #[cfg(feature = "ws")]
     let ws_url = std::env::var("CIRCLES_RPC_WS_URL")
         .ok()
         .or_else(|| Some(DEFAULT_WS_URL.to_string()));

--- a/crates/pathfinder/src/convenience.rs
+++ b/crates/pathfinder/src/convenience.rs
@@ -1,10 +1,11 @@
 use crate::PathfinderError;
 use crate::rpc::u256_to_u192;
 use crate::{FlowEdge, PathData, Stream};
-use crate::{FlowMatrix, find_path_with_params};
+use crate::{FlowMatrix, find_path_with_params_via_rpc};
 use alloy_primitives::Address;
 use alloy_primitives::aliases::{U192, U256};
 use alloy_sol_types::SolValue;
+use circles_rpc::CirclesRpc;
 use circles_types::FindPathParams;
 use circles_types::TransferStep;
 
@@ -48,16 +49,23 @@ use circles_types::TransferStep;
 /// # Ok(())
 /// # }
 /// ```
+pub async fn prepare_flow_for_contract_via_rpc(
+    rpc: &CirclesRpc,
+    params: FindPathParams,
+) -> Result<PathData, PathfinderError> {
+    let transfers = find_path_with_params_via_rpc(rpc, params.clone()).await?;
+    let target_flow = u256_to_u192(params.target_flow)?;
+
+    PathData::from_transfers(&transfers, params.from, params.to, target_flow)
+}
+
+/// High-level helper that performs pathfinding and flow-matrix preparation from an RPC URL.
 pub async fn prepare_flow_for_contract(
     rpc_url: &str,
     params: FindPathParams,
 ) -> Result<PathData, PathfinderError> {
-    // Step 1: Find the path
-    let transfers = find_path_with_params(rpc_url, params.clone()).await?;
-    let target_flow = u256_to_u192(params.target_flow)?;
-
-    // Step 2: Create PathData from transfers (handles flow calculation internally)
-    PathData::from_transfers(&transfers, params.from, params.to, target_flow)
+    let rpc = CirclesRpc::try_from_http(rpc_url)?;
+    prepare_flow_for_contract_via_rpc(&rpc, params).await
 }
 
 /// Prepare flow for contract using individual parameters (legacy compatibility)
@@ -96,11 +104,11 @@ pub async fn prepare_flow_for_contract_simple(
 /// # Returns
 /// A tuple of (available_flow, transfers) where available_flow is the actual
 /// amount that can be transferred.
-pub async fn get_available_flow(
-    rpc_url: &str,
+pub async fn get_available_flow_via_rpc(
+    rpc: &CirclesRpc,
     params: FindPathParams,
 ) -> Result<(U192, Vec<TransferStep>), PathfinderError> {
-    let transfers = find_path_with_params(rpc_url, params.clone()).await?;
+    let transfers = find_path_with_params_via_rpc(rpc, params.clone()).await?;
 
     let available_flow: U192 = transfers
         .iter()
@@ -109,6 +117,15 @@ pub async fn get_available_flow(
         .sum();
 
     Ok((available_flow, transfers))
+}
+
+/// Get the maximum available flow between two addresses from an RPC URL.
+pub async fn get_available_flow(
+    rpc_url: &str,
+    params: FindPathParams,
+) -> Result<(U192, Vec<TransferStep>), PathfinderError> {
+    let rpc = CirclesRpc::try_from_http(rpc_url)?;
+    get_available_flow_via_rpc(&rpc, params).await
 }
 
 pub fn encode_redeem_trusted_data(
@@ -161,6 +178,26 @@ mod tests {
         .await;
 
         // Should fail with RPC error, not panic
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_prepare_flow_for_contract_via_rpc() {
+        let rpc = CirclesRpc::try_from_http("http://invalid-rpc.com").unwrap();
+        let params = FindPathParams {
+            from: Address::ZERO,
+            to: Address::from([1u8; 20]),
+            target_flow: U256::from(1000u64),
+            use_wrapped_balances: Some(true),
+            from_tokens: None,
+            to_tokens: None,
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            max_transfers: None,
+        };
+
+        let result = prepare_flow_for_contract_via_rpc(&rpc, params).await;
         assert!(result.is_err());
     }
 

--- a/crates/pathfinder/src/flow.rs
+++ b/crates/pathfinder/src/flow.rs
@@ -8,8 +8,31 @@ use crate::{FlowEdge, FlowMatrix, PathfinderError, Stream};
 use alloy_primitives::aliases::{U192, U256};
 use alloy_primitives::{Address, Bytes};
 use circles_types::TransferStep;
+use std::collections::HashSet;
 
 use crate::packing::{pack_coordinates, transform_to_flow_vertices};
+
+fn detect_terminal_edges(transfers: &[TransferStep], receiver: Address) -> HashSet<usize> {
+    let mut terminal_edges = HashSet::new();
+    let mut edges_to_receiver = Vec::new();
+    let mut self_loop_index = None;
+
+    for (index, transfer) in transfers.iter().enumerate() {
+        if transfer.from_address == receiver && transfer.to_address == receiver {
+            self_loop_index = Some(index);
+        } else if transfer.to_address == receiver {
+            edges_to_receiver.push(index);
+        }
+    }
+
+    if let Some(index) = self_loop_index {
+        terminal_edges.insert(index);
+    } else {
+        terminal_edges.extend(edges_to_receiver);
+    }
+
+    terminal_edges
+}
 
 /// Create a flow matrix from a sequence of transfer steps.
 ///
@@ -75,23 +98,26 @@ pub fn create_flow_matrix(
     }
 
     let (flow_vertices, idx) = transform_to_flow_vertices(transfers, sender, receiver);
+    let terminal_edge_indices = detect_terminal_edges(transfers, receiver);
 
     // Build edges
-    let mut flow_edges: Vec<FlowEdge> = transfers
+    let flow_edges: Vec<FlowEdge> = transfers
         .iter()
-        .map(|t| FlowEdge {
-            streamSinkId: if t.to_address == receiver { 1 } else { 0 },
+        .enumerate()
+        .map(|(index, t)| FlowEdge {
+            streamSinkId: if terminal_edge_indices.contains(&index) {
+                1
+            } else {
+                0
+            },
             amount: t.value,
         })
         .collect();
 
-    // Ensure at least one terminal edge
-    if !flow_edges.iter().any(|e| e.streamSinkId == 1) {
-        let fallback = transfers
-            .iter()
-            .rposition(|t| t.to_address == receiver)
-            .unwrap_or(flow_edges.len() - 1);
-        flow_edges[fallback].streamSinkId = 1;
+    if terminal_edge_indices.is_empty() {
+        return Err(PathfinderError::RpcResponse(format!(
+            "No terminal edges detected. Flow must have at least one edge delivering to receiver {receiver:#x}"
+        )));
     }
 
     // Check terminal balance
@@ -108,11 +134,11 @@ pub fn create_flow_matrix(
     }
 
     // Build streams
-    let term_edge_ids: Vec<u16> = flow_edges
+    let mut term_edge_ids: Vec<u16> = terminal_edge_indices
         .iter()
-        .enumerate()
-        .filter_map(|(i, e)| (e.streamSinkId == 1).then_some(i as u16))
+        .map(|index| *index as u16)
         .collect();
+    term_edge_ids.sort_unstable();
 
     let streams = vec![Stream {
         sourceCoordinate: *idx.get(&sender).unwrap() as u16,

--- a/crates/pathfinder/src/flow.rs
+++ b/crates/pathfinder/src/flow.rs
@@ -163,3 +163,20 @@ pub fn create_flow_matrix(
         source_coordinate: U256::from(*idx.get(&sender).unwrap()),
     })
 }
+
+/// Clone flow-matrix streams and optionally attach transaction data to the first stream.
+///
+/// This mirrors the TypeScript helper used before contract submission, but keeps
+/// the Rust contract-facing `Bytes` representation instead of hex strings.
+pub fn prepare_flow_matrix_streams(
+    flow_matrix: &FlowMatrix,
+    tx_data: Option<Bytes>,
+) -> Vec<Stream> {
+    let mut streams = flow_matrix.streams.clone();
+    if let Some(tx_data) = tx_data
+        && let Some(first) = streams.first_mut()
+    {
+        first.data = tx_data;
+    }
+    streams
+}

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -110,8 +110,8 @@ pub use convenience::{
 
 pub use path::{
     assert_no_netted_flow_mismatch, compute_netted_flow, expected_unwrapped_totals,
-    replace_wrapped_tokens, replace_wrapped_tokens_with_avatars, shrink_path_values,
-    token_info_map_from_path, wrapped_totals_from_path,
+    expected_unwrapped_totals_at, replace_wrapped_tokens, replace_wrapped_tokens_with_avatars,
+    shrink_path_values, token_info_map_from_path, wrapped_totals_from_path,
 };
 
 // Utility functions for advanced users

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -110,7 +110,8 @@ pub use convenience::{
 
 pub use path::{
     assert_no_netted_flow_mismatch, compute_netted_flow, expected_unwrapped_totals,
-    replace_wrapped_tokens, shrink_path_values, token_info_map_from_path, wrapped_totals_from_path,
+    replace_wrapped_tokens, replace_wrapped_tokens_with_avatars, shrink_path_values,
+    token_info_map_from_path, wrapped_totals_from_path,
 };
 
 // Utility functions for advanced users

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -111,8 +111,9 @@ pub use convenience::{
 
 pub use path::{
     assert_no_netted_flow_mismatch, compute_netted_flow, expected_unwrapped_totals,
-    expected_unwrapped_totals_at, replace_wrapped_tokens, replace_wrapped_tokens_with_avatars,
-    shrink_path_values, token_info_map_from_path, wrapped_totals_from_path,
+    expected_unwrapped_totals_at, get_wrapped_tokens_from_path, replace_wrapped_tokens,
+    replace_wrapped_tokens_with_avatars, shrink_path_values, token_info_map_from_path,
+    wrapped_totals_from_path,
 };
 
 // Utility functions for advanced users

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -113,7 +113,7 @@ pub use path::{
     assert_no_netted_flow_mismatch, compute_netted_flow, expected_unwrapped_totals,
     expected_unwrapped_totals_at, get_wrapped_tokens_from_path, replace_wrapped_tokens,
     replace_wrapped_tokens_with_avatars, shrink_path_values, token_info_map_from_path,
-    wrapped_totals_from_path,
+    token_info_map_from_path_via_rpc, token_info_map_from_path_with_url, wrapped_totals_from_path,
 };
 
 // Utility functions for advanced users

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -90,7 +90,7 @@ mod rpc;
 use alloy_primitives::{U256, aliases::U192};
 
 // Core public API - the main functions users need
-pub use flow::create_flow_matrix;
+pub use flow::{create_flow_matrix, prepare_flow_matrix_streams};
 pub mod path;
 
 // RPC functionality

--- a/crates/pathfinder/src/lib.rs
+++ b/crates/pathfinder/src/lib.rs
@@ -95,7 +95,7 @@ pub mod path;
 
 // RPC functionality
 pub use circles_types::FindPathParams;
-pub use rpc::{find_path, find_path_with_params};
+pub use rpc::{find_path, find_path_via_rpc, find_path_with_params, find_path_with_params_via_rpc};
 
 // Hub contract integration types and functions
 use alloy_primitives::Address;
@@ -105,7 +105,8 @@ pub use hub::PathData;
 // High-level convenience functions
 pub use convenience::{
     encode_redeem_flow_matrix, encode_redeem_trusted_data, get_available_flow,
-    prepare_flow_for_contract, prepare_flow_for_contract_simple,
+    get_available_flow_via_rpc, prepare_flow_for_contract, prepare_flow_for_contract_simple,
+    prepare_flow_for_contract_via_rpc,
 };
 
 pub use path::{

--- a/crates/pathfinder/src/path.rs
+++ b/crates/pathfinder/src/path.rs
@@ -276,17 +276,29 @@ fn get_source_and_sink(
     override_sink: Option<Address>,
 ) -> Result<(Address, Address), PathfinderError> {
     use std::collections::HashSet;
-    let senders: HashSet<Address> = path.transfers.iter().map(|t| t.from).collect();
-    let receivers: HashSet<Address> = path.transfers.iter().map(|t| t.to).collect();
+
+    let mut senders = Vec::new();
+    let mut receivers = Vec::new();
+    let mut sender_set = HashSet::new();
+    let mut receiver_set = HashSet::new();
+
+    for transfer in &path.transfers {
+        if sender_set.insert(transfer.from) {
+            senders.push(transfer.from);
+        }
+        if receiver_set.insert(transfer.to) {
+            receivers.push(transfer.to);
+        }
+    }
 
     let source = senders
         .iter()
-        .find(|a| !receivers.contains(*a))
+        .find(|a| !receiver_set.contains(*a))
         .copied()
         .or(override_source);
     let sink = receivers
         .iter()
-        .find(|a| !senders.contains(*a))
+        .find(|a| !sender_set.contains(*a))
         .copied()
         .or(override_sink);
 

--- a/crates/pathfinder/src/path.rs
+++ b/crates/pathfinder/src/path.rs
@@ -65,24 +65,31 @@ pub fn wrapped_totals_from_path(
     out
 }
 
-/// Convert wrapped totals to their underlying avatar/token totals.
+/// Convert wrapped totals to their underlying avatar/token totals using the current time.
 ///
-/// Inflationary wrappers are converted back to attoCircles using the converter
-/// and the token's timestamp hint; demurraged wrappers are currently identity.
+/// This mirrors the TypeScript pathfinder helper, which calls the converter
+/// with its default "now" semantics for inflationary wrappers.
 pub fn expected_unwrapped_totals(
     wrapped_totals: &HashMap<Address, (U256, String)>,
     token_info_map: &HashMap<Address, TokenInfo>,
 ) -> HashMap<Address, (U256, Address)> {
+    expected_unwrapped_totals_at(wrapped_totals, token_info_map, None)
+}
+
+/// Convert wrapped totals to their underlying avatar/token totals at an explicit timestamp.
+///
+/// Use this when you need deterministic conversion behavior instead of the
+/// TypeScript-compatible default "now" semantics.
+pub fn expected_unwrapped_totals_at(
+    wrapped_totals: &HashMap<Address, (U256, String)>,
+    token_info_map: &HashMap<Address, TokenInfo>,
+    now_unix_seconds: Option<u64>,
+) -> HashMap<Address, (U256, Address)> {
     let mut out = HashMap::new();
     for (wrapper, (total, ty)) in wrapped_totals {
         if let Some(info) = token_info_map.get(wrapper) {
-            let ts_hint = if info.timestamp > 0 {
-                Some(info.timestamp)
-            } else {
-                None
-            };
             let amount = if ty == "CrcV2_ERC20WrapperDeployed_Inflationary" {
-                atto_static_circles_to_atto_circles(*total, ts_hint)
+                atto_static_circles_to_atto_circles(*total, now_unix_seconds)
             } else {
                 *total
             };

--- a/crates/pathfinder/src/path.rs
+++ b/crates/pathfinder/src/path.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 ///
 /// Normalizes wrapper token types so non-inflationary wrappers are coerced to
 /// `CrcV2_ERC20WrapperDeployed_Demurraged` for downstream logic.
-pub async fn token_info_map_from_path(
+pub async fn token_info_map_from_path_via_rpc(
     current_avatar: Address,
     rpc: &CirclesRpc,
     path: &PathfindingResult,
@@ -40,6 +40,25 @@ pub async fn token_info_map_from_path(
         map.insert(info.token, info);
     }
     Ok(map)
+}
+
+/// Compatibility wrapper that preserves the existing Rust client-based entrypoint.
+pub async fn token_info_map_from_path(
+    current_avatar: Address,
+    rpc: &CirclesRpc,
+    path: &PathfindingResult,
+) -> Result<HashMap<Address, TokenInfo>, PathfinderError> {
+    token_info_map_from_path_via_rpc(current_avatar, rpc, path).await
+}
+
+/// Convenience wrapper for callers that only have an RPC URL.
+pub async fn token_info_map_from_path_with_url(
+    current_avatar: Address,
+    rpc_url: &str,
+    path: &PathfindingResult,
+) -> Result<HashMap<Address, TokenInfo>, PathfinderError> {
+    let rpc = CirclesRpc::try_from_http(rpc_url)?;
+    token_info_map_from_path_via_rpc(current_avatar, &rpc, path).await
 }
 
 /// Accumulate totals for wrapped tokens present in a path.

--- a/crates/pathfinder/src/path.rs
+++ b/crates/pathfinder/src/path.rs
@@ -65,6 +65,14 @@ pub fn wrapped_totals_from_path(
     out
 }
 
+/// Additive parity alias for the TypeScript `getWrappedTokensFromPath` helper.
+pub fn get_wrapped_tokens_from_path(
+    path: &PathfindingResult,
+    token_info_map: &HashMap<Address, TokenInfo>,
+) -> HashMap<Address, (U256, String)> {
+    wrapped_totals_from_path(path, token_info_map)
+}
+
 /// Convert wrapped totals to their underlying avatar/token totals using the current time.
 ///
 /// This mirrors the TypeScript pathfinder helper, which calls the converter
@@ -88,12 +96,16 @@ pub fn expected_unwrapped_totals_at(
     let mut out = HashMap::new();
     for (wrapper, (total, ty)) in wrapped_totals {
         if let Some(info) = token_info_map.get(wrapper) {
-            let amount = if ty == "CrcV2_ERC20WrapperDeployed_Inflationary" {
-                atto_static_circles_to_atto_circles(*total, now_unix_seconds)
-            } else {
-                *total
-            };
-            out.insert(*wrapper, (amount, info.token_owner));
+            match ty.as_str() {
+                "CrcV2_ERC20WrapperDeployed_Demurraged" => {
+                    out.insert(*wrapper, (*total, info.token_owner));
+                }
+                "CrcV2_ERC20WrapperDeployed_Inflationary" => {
+                    let amount = atto_static_circles_to_atto_circles(*total, now_unix_seconds);
+                    out.insert(*wrapper, (amount, info.token_owner));
+                }
+                _ => {}
+            }
         }
     }
     out
@@ -150,10 +162,10 @@ pub fn replace_wrapped_tokens(
         .map(|edge| {
             let token_owner = wrapper_to_avatar
                 .get(&edge.token_owner.to_lowercase())
-                .copied()
-                .unwrap_or_else(|| Address::from_str(&edge.token_owner).unwrap_or(Address::ZERO));
+                .map(|avatar| format!("{avatar:#x}"))
+                .unwrap_or_else(|| edge.token_owner.clone());
             circles_types::PathfindingTransferStep {
-                token_owner: format!("{token_owner:#x}"),
+                token_owner,
                 ..edge.clone()
             }
         })

--- a/crates/pathfinder/src/path.rs
+++ b/crates/pathfinder/src/path.rs
@@ -96,6 +96,38 @@ pub fn expected_unwrapped_totals(
 ///
 /// Produces a new path suitable for flow matrix construction where token_owner
 /// is always the underlying avatar (not the wrapper contract).
+pub fn replace_wrapped_tokens_with_avatars(
+    path: &PathfindingResult,
+    token_info_map: &HashMap<Address, TokenInfo>,
+) -> PathfindingResult {
+    let transfers = path
+        .transfers
+        .iter()
+        .map(|edge| {
+            let token_owner = Address::from_str(&edge.token_owner)
+                .ok()
+                .and_then(|owner| token_info_map.get(&owner))
+                .filter(|info| info.token_type.starts_with("CrcV2_ERC20WrapperDeployed"))
+                .map(|info| format!("{:#x}", info.token_owner))
+                .unwrap_or_else(|| edge.token_owner.clone());
+
+            circles_types::PathfindingTransferStep {
+                token_owner,
+                ..edge.clone()
+            }
+        })
+        .collect();
+
+    PathfindingResult {
+        max_flow: path.max_flow,
+        transfers,
+    }
+}
+
+/// Replace wrapped token addresses in a path with their underlying avatar tokens.
+///
+/// Produces a new path suitable for flow matrix construction where token_owner
+/// is always the underlying avatar (not the wrapper contract).
 pub fn replace_wrapped_tokens(
     path: &PathfindingResult,
     unwrapped: &HashMap<Address, (U256, Address)>,

--- a/crates/pathfinder/src/rpc.rs
+++ b/crates/pathfinder/src/rpc.rs
@@ -73,14 +73,13 @@ fn convert_step(step: &PathfindingTransferStep) -> Result<TransferStep, Pathfind
 ///
 /// - [`PathfinderError::Transport`] - Network/HTTP or underlying client errors
 /// - [`PathfinderError::RpcResponse`] - Invalid RPC response or protocol errors
-pub async fn find_path(
-    rpc_url: &str,
+pub async fn find_path_via_rpc(
+    rpc: &CirclesRpc,
     from: Address,
     to: Address,
     target_flow: U192,
     with_wrap: bool,
 ) -> Result<Vec<TransferStep>, PathfinderError> {
-    let rpc = CirclesRpc::try_from_http(rpc_url)?;
     let params = FindPathParams {
         from,
         to,
@@ -93,6 +92,26 @@ pub async fn find_path(
         simulated_balances: None,
         max_transfers: None,
     };
+    find_path_with_params_via_rpc(rpc, params).await
+}
+
+/// Find an optimal path between two addresses using an existing [`CirclesRpc`] client.
+pub async fn find_path(
+    rpc_url: &str,
+    from: Address,
+    to: Address,
+    target_flow: U192,
+    with_wrap: bool,
+) -> Result<Vec<TransferStep>, PathfinderError> {
+    let rpc = CirclesRpc::try_from_http(rpc_url)?;
+    find_path_via_rpc(&rpc, from, to, target_flow, with_wrap).await
+}
+
+/// Find a path using structured parameters and an existing [`CirclesRpc`] client.
+pub async fn find_path_with_params_via_rpc(
+    rpc: &CirclesRpc,
+    params: FindPathParams,
+) -> Result<Vec<TransferStep>, PathfinderError> {
     let result: PathfindingResult = rpc.pathfinder().find_path(params).await?;
     result
         .transfers
@@ -107,10 +126,5 @@ pub async fn find_path_with_params(
     params: FindPathParams,
 ) -> Result<Vec<TransferStep>, PathfinderError> {
     let rpc = CirclesRpc::try_from_http(rpc_url)?;
-    let result: PathfindingResult = rpc.pathfinder().find_path(params).await?;
-    result
-        .transfers
-        .iter()
-        .map(convert_step)
-        .collect::<Result<Vec<_>, _>>()
+    find_path_with_params_via_rpc(&rpc, params).await
 }

--- a/crates/pathfinder/tests/flow_matrix_tests.rs
+++ b/crates/pathfinder/tests/flow_matrix_tests.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::{U256, aliases::U192};
-use circles_pathfinder::{PathfinderError, create_flow_matrix};
+use alloy_primitives::{Bytes, U256, aliases::U192};
+use circles_pathfinder::{
+    PathfinderError, Stream, create_flow_matrix, prepare_flow_matrix_streams,
+};
 
 mod common;
 
@@ -242,4 +244,50 @@ fn test_create_flow_matrix_source_coordinate() {
         .expect("Sender should be in vertices");
 
     assert_eq!(matrix.source_coordinate, U256::from(sender_index));
+}
+
+#[test]
+fn test_prepare_flow_matrix_streams_without_tx_data() {
+    let matrix = circles_pathfinder::FlowMatrix {
+        flow_vertices: vec![],
+        flow_edges: vec![],
+        streams: vec![Stream {
+            sourceCoordinate: 0,
+            flowEdgeIds: vec![1, 2],
+            data: Bytes::from(vec![0x01, 0x02]),
+        }],
+        packed_coordinates: vec![],
+        source_coordinate: U256::ZERO,
+    };
+
+    let streams = prepare_flow_matrix_streams(&matrix, None);
+    assert_eq!(streams.len(), 1);
+    assert_eq!(streams[0].data, Bytes::from(vec![0x01, 0x02]));
+}
+
+#[test]
+fn test_prepare_flow_matrix_streams_with_tx_data() {
+    let matrix = circles_pathfinder::FlowMatrix {
+        flow_vertices: vec![],
+        flow_edges: vec![],
+        streams: vec![
+            Stream {
+                sourceCoordinate: 0,
+                flowEdgeIds: vec![1, 2],
+                data: Bytes::from(vec![0x01]),
+            },
+            Stream {
+                sourceCoordinate: 1,
+                flowEdgeIds: vec![3],
+                data: Bytes::from(vec![0x02]),
+            },
+        ],
+        packed_coordinates: vec![],
+        source_coordinate: U256::ZERO,
+    };
+
+    let streams = prepare_flow_matrix_streams(&matrix, Some(Bytes::from(vec![0xaa, 0xbb])));
+    assert_eq!(streams.len(), 2);
+    assert_eq!(streams[0].data, Bytes::from(vec![0xaa, 0xbb]));
+    assert_eq!(streams[1].data, Bytes::from(vec![0x02]));
 }

--- a/crates/pathfinder/tests/flow_matrix_tests.rs
+++ b/crates/pathfinder/tests/flow_matrix_tests.rs
@@ -141,17 +141,16 @@ fn test_create_flow_matrix_no_terminal_edges() {
 
     let result = create_flow_matrix(sender, receiver, value, &transfers);
 
-    // The function automatically makes the last edge terminal
-    // Since the transfer doesn't go to receiver but value matches, it should succeed
-    // with the last edge marked as terminal
     assert!(
-        result.is_ok(),
-        "Should succeed by making last edge terminal"
+        result.is_err(),
+        "Should fail when no edge reaches the receiver"
     );
-
-    let matrix = result.unwrap();
-    assert_eq!(matrix.flow_edges.len(), 1);
-    assert_eq!(matrix.flow_edges[0].streamSinkId, 1); // Should be terminal
+    match result.unwrap_err() {
+        PathfinderError::RpcResponse(message) => {
+            assert!(message.contains("No terminal edges detected"));
+        }
+        other => panic!("Expected RpcResponse error, got: {other:?}"),
+    }
 }
 
 #[test]
@@ -182,6 +181,31 @@ fn test_create_flow_matrix_multiple_terminal_edges() {
 
     // Stream should reference both terminal edges
     assert_eq!(matrix.streams[0].flowEdgeIds, vec![0, 1]);
+}
+
+#[test]
+fn test_create_flow_matrix_receiver_self_loop_is_only_terminal_edge() {
+    let sender = common::addresses::sender();
+    let receiver = common::addresses::receiver();
+    let value = common::wei_from_str(common::ONE_ETH_WEI);
+
+    let transfers = vec![
+        common::sample_transfer_step(sender, receiver, sender, value),
+        common::sample_transfer_step(receiver, receiver, receiver, value),
+    ];
+
+    let result = create_flow_matrix(sender, receiver, value, &transfers);
+    assert!(
+        result.is_ok(),
+        "Should succeed with receiver self-loop aggregation"
+    );
+
+    let matrix = result.unwrap();
+
+    assert_eq!(matrix.flow_edges.len(), 2);
+    assert_eq!(matrix.flow_edges[0].streamSinkId, 0);
+    assert_eq!(matrix.flow_edges[1].streamSinkId, 1);
+    assert_eq!(matrix.streams[0].flowEdgeIds, vec![1]);
 }
 
 #[test]

--- a/crates/pathfinder/tests/integration_tests.rs
+++ b/crates/pathfinder/tests/integration_tests.rs
@@ -110,13 +110,9 @@ async fn test_pathfinding_with_different_values() {
             // If we get transfers, verify we can create a valid matrix
             let matrix_result = create_flow_matrix(sender, receiver, value, &transfers);
 
-            if matrix_result.is_ok() {
-                println!("✓ Value {value} works end-to-end");
-            } else {
-                println!(
-                    "✗ Value {value} failed matrix creation: {:?}",
-                    matrix_result.unwrap_err()
-                );
+            match matrix_result {
+                Ok(_) => println!("✓ Value {value} works end-to-end"),
+                Err(err) => println!("✗ Value {value} failed matrix creation: {err:?}"),
             }
         } else {
             println!(
@@ -191,10 +187,9 @@ async fn test_pathfinding_with_wrapping_variations() {
 
                 // Verify we can create a matrix from these transfers
                 let matrix_result = create_flow_matrix(sender, receiver, value, &transfers);
-                if matrix_result.is_ok() {
-                    println!("✓ Matrix creation also succeeded");
-                } else {
-                    println!("✗ Matrix creation failed: {:?}", matrix_result.unwrap_err());
+                match matrix_result {
+                    Ok(_) => println!("✓ Matrix creation also succeeded"),
+                    Err(err) => println!("✗ Matrix creation failed: {err:?}"),
                 }
             }
             Err(e) => {

--- a/crates/pathfinder/tests/path_wrapper_tests.rs
+++ b/crates/pathfinder/tests/path_wrapper_tests.rs
@@ -224,3 +224,127 @@ fn expected_unwrapped_totals_ignore_unknown_wrapper_types() {
 
     assert!(unwrapped.is_empty());
 }
+
+#[test]
+fn compute_netted_flow_matches_ts_balances() {
+    let source = address!("0x1000000000000000000000000000000000000001");
+    let intermediate = address!("0x2000000000000000000000000000000000000002");
+    let sink = address!("0x3000000000000000000000000000000000000003");
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(5u64),
+        transfers: vec![
+            PathfindingTransferStep {
+                from: source,
+                to: intermediate,
+                token_owner: format!("{source:#x}"),
+                value: alloy_primitives::U256::from(5u64),
+            },
+            PathfindingTransferStep {
+                from: intermediate,
+                to: sink,
+                token_owner: format!("{intermediate:#x}"),
+                value: alloy_primitives::U256::from(5u64),
+            },
+        ],
+    };
+
+    let net = circles_pathfinder::compute_netted_flow(&path);
+    let five = alloy_primitives::I256::from_raw(alloy_primitives::U256::from(5u64));
+
+    assert_eq!(net.get(&source), Some(&(-five)));
+    assert_eq!(net.get(&intermediate), Some(&alloy_primitives::I256::ZERO));
+    assert_eq!(net.get(&sink), Some(&five));
+}
+
+#[test]
+fn assert_no_netted_flow_mismatch_accepts_closed_loop_with_overrides() {
+    let avatar = address!("0x4000000000000000000000000000000000000004");
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(7u64),
+        transfers: vec![PathfindingTransferStep {
+            from: avatar,
+            to: avatar,
+            token_owner: format!("{avatar:#x}"),
+            value: alloy_primitives::U256::from(7u64),
+        }],
+    };
+
+    let result =
+        circles_pathfinder::assert_no_netted_flow_mismatch(&path, Some(avatar), Some(avatar));
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn assert_no_netted_flow_mismatch_uses_ts_source_order_on_malformed_paths() {
+    let first_source = address!("0x5000000000000000000000000000000000000005");
+    let second_source = address!("0x6000000000000000000000000000000000000006");
+    let sink = address!("0x7000000000000000000000000000000000000007");
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(8u64),
+        transfers: vec![
+            PathfindingTransferStep {
+                from: first_source,
+                to: sink,
+                token_owner: format!("{first_source:#x}"),
+                value: alloy_primitives::U256::from(5u64),
+            },
+            PathfindingTransferStep {
+                from: second_source,
+                to: sink,
+                token_owner: format!("{second_source:#x}"),
+                value: alloy_primitives::U256::from(3u64),
+            },
+        ],
+    };
+
+    let err = circles_pathfinder::assert_no_netted_flow_mismatch(&path, None, None).unwrap_err();
+
+    match err {
+        circles_pathfinder::PathfinderError::RpcResponse(message) => {
+            assert!(message.contains(&format!("{second_source:#x}")));
+        }
+        other => panic!("expected RpcResponse, got {other:?}"),
+    }
+}
+
+#[test]
+fn shrink_path_values_scales_and_drops_subunit_edges() {
+    let source = address!("0x8000000000000000000000000000000000000008");
+    let intermediate = address!("0x9000000000000000000000000000000000000009");
+    let sink = address!("0xa00000000000000000000000000000000000000a");
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(5u64),
+        transfers: vec![
+            PathfindingTransferStep {
+                from: source,
+                to: sink,
+                token_owner: format!("{source:#x}"),
+                value: alloy_primitives::U256::from(4u64),
+            },
+            PathfindingTransferStep {
+                from: source,
+                to: intermediate,
+                token_owner: format!("{source:#x}"),
+                value: alloy_primitives::U256::from(1u64),
+            },
+        ],
+    };
+
+    let shrunk = circles_pathfinder::shrink_path_values(
+        &path,
+        sink,
+        alloy_primitives::U256::from(500_000_000_000u64),
+    );
+
+    assert_eq!(shrunk.max_flow, alloy_primitives::U256::from(2u64));
+    assert_eq!(shrunk.transfers.len(), 1);
+    assert_eq!(shrunk.transfers[0].to, sink);
+    assert_eq!(
+        shrunk.transfers[0].value,
+        alloy_primitives::U256::from(2u64)
+    );
+}

--- a/crates/pathfinder/tests/path_wrapper_tests.rs
+++ b/crates/pathfinder/tests/path_wrapper_tests.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::address;
+use circles_rpc::CirclesRpc;
 use circles_types::{PathfindingResult, PathfindingTransferStep};
 
 mod common;
@@ -347,4 +348,59 @@ fn shrink_path_values_scales_and_drops_subunit_edges() {
         shrunk.transfers[0].value,
         alloy_primitives::U256::from(2u64)
     );
+}
+
+#[tokio::test]
+async fn token_info_map_from_path_via_rpc_returns_transport_error_for_invalid_target() {
+    let current = address!("0xb00000000000000000000000000000000000000b");
+    let receiver = address!("0xc00000000000000000000000000000000000000c");
+    let wrapper = address!("0xd00000000000000000000000000000000000000d");
+    let rpc = CirclesRpc::try_from_http("http://invalid-rpc-url.com").unwrap();
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(1u64),
+        transfers: vec![PathfindingTransferStep {
+            from: current,
+            to: receiver,
+            token_owner: format!("{wrapper:#x}"),
+            value: alloy_primitives::U256::from(1u64),
+        }],
+    };
+
+    let err = circles_pathfinder::token_info_map_from_path_via_rpc(current, &rpc, &path)
+        .await
+        .unwrap_err();
+
+    match err {
+        circles_pathfinder::PathfinderError::Transport(_) => {}
+        other => panic!("expected transport error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn token_info_map_from_path_with_url_returns_transport_error_for_invalid_target() {
+    let current = address!("0xe00000000000000000000000000000000000000e");
+    let receiver = address!("0xf00000000000000000000000000000000000000f");
+    let wrapper = address!("0x1111111111111111111111111111111111111112");
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(1u64),
+        transfers: vec![PathfindingTransferStep {
+            from: current,
+            to: receiver,
+            token_owner: format!("{wrapper:#x}"),
+            value: alloy_primitives::U256::from(1u64),
+        }],
+    };
+
+    let err = circles_pathfinder::token_info_map_from_path_with_url(
+        current,
+        "http://invalid-rpc-url.com",
+        &path,
+    )
+    .await
+    .unwrap_err();
+
+    match err {
+        circles_pathfinder::PathfinderError::Transport(_) => {}
+        other => panic!("expected transport error, got {other:?}"),
+    }
 }

--- a/crates/pathfinder/tests/path_wrapper_tests.rs
+++ b/crates/pathfinder/tests/path_wrapper_tests.rs
@@ -138,3 +138,89 @@ fn replaces_wrapped_tokens_with_avatar_addresses() {
     assert_eq!(rewritten.transfers[0].to, path.transfers[0].to);
     assert_eq!(rewritten.transfers[0].value, path.transfers[0].value);
 }
+
+#[test]
+fn get_wrapped_tokens_alias_matches_existing_helper() {
+    let current = address!("0xde374ece6fa50e781e81aac78e811b33d16912c7");
+    let receiver = address!("0x1111111111111111111111111111111111111111");
+    let wrapper = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(1u64),
+        transfers: vec![PathfindingTransferStep {
+            from: current,
+            to: receiver,
+            token_owner: format!("{wrapper:#x}"),
+            value: alloy_primitives::U256::from(42u64),
+        }],
+    };
+
+    let mut info_map = std::collections::HashMap::new();
+    info_map.insert(
+        wrapper,
+        common::path_helpers::mock_token_info(
+            wrapper,
+            current,
+            "CrcV2_ERC20WrapperDeployed_Demurraged",
+        ),
+    );
+
+    let via_existing = circles_pathfinder::wrapped_totals_from_path(&path, &info_map);
+    let via_alias = circles_pathfinder::get_wrapped_tokens_from_path(&path, &info_map);
+
+    assert_eq!(via_alias, via_existing);
+}
+
+#[test]
+fn replace_wrapped_tokens_preserves_unmapped_owner_string() {
+    let current = address!("0xde374ece6fa50e781e81aac78e811b33d16912c7");
+    let receiver = address!("0x1111111111111111111111111111111111111111");
+    let original_owner = "NOT_A_VALID_ADDRESS".to_string();
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(1u64),
+        transfers: vec![PathfindingTransferStep {
+            from: current,
+            to: receiver,
+            token_owner: original_owner.clone(),
+            value: alloy_primitives::U256::from(1u64),
+        }],
+    };
+
+    let rewritten =
+        circles_pathfinder::replace_wrapped_tokens(&path, &std::collections::HashMap::new());
+
+    assert_eq!(rewritten.transfers[0].token_owner, original_owner);
+}
+
+#[test]
+fn expected_unwrapped_totals_ignore_unknown_wrapper_types() {
+    use alloy_primitives::U256;
+    use std::collections::HashMap;
+
+    let wrapper = address!("0xdddddddddddddddddddddddddddddddddddddddd");
+    let avatar = address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+    let mut totals: HashMap<_, (U256, String)> = HashMap::new();
+    totals.insert(
+        wrapper,
+        (
+            U256::from(1_000u64),
+            "CrcV2_ERC20WrapperDeployed_Experimental".into(),
+        ),
+    );
+
+    let mut info_map = HashMap::new();
+    info_map.insert(
+        wrapper,
+        common::path_helpers::mock_token_info(
+            wrapper,
+            avatar,
+            "CrcV2_ERC20WrapperDeployed_Experimental",
+        ),
+    );
+
+    let unwrapped = circles_pathfinder::expected_unwrapped_totals_at(&totals, &info_map, Some(1));
+
+    assert!(unwrapped.is_empty());
+}

--- a/crates/pathfinder/tests/path_wrapper_tests.rs
+++ b/crates/pathfinder/tests/path_wrapper_tests.rs
@@ -82,3 +82,58 @@ fn converts_inflationary_wrapper_totals() {
     assert!(diff < U256::from(1_000u64));
     assert_eq!(*owner, avatar);
 }
+
+#[test]
+fn replaces_wrapped_tokens_with_avatar_addresses() {
+    let current = address!("0xde374ece6fa50e781e81aac78e811b33d16912c7");
+    let receiver = address!("0x1111111111111111111111111111111111111111");
+    let wrapper = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let wrapped_owner = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    let plain_owner = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+
+    let path = PathfindingResult {
+        max_flow: alloy_primitives::U256::from(2u64),
+        transfers: vec![
+            PathfindingTransferStep {
+                from: current,
+                to: receiver,
+                token_owner: format!("{wrapper:#x}"),
+                value: alloy_primitives::U256::from(1u64),
+            },
+            PathfindingTransferStep {
+                from: current,
+                to: receiver,
+                token_owner: format!("{plain_owner:#x}"),
+                value: alloy_primitives::U256::from(1u64),
+            },
+        ],
+    };
+
+    let mut info_map = std::collections::HashMap::new();
+    info_map.insert(
+        wrapper,
+        common::path_helpers::mock_token_info(
+            wrapper,
+            wrapped_owner,
+            "CrcV2_ERC20WrapperDeployed_Demurraged",
+        ),
+    );
+    info_map.insert(
+        plain_owner,
+        common::path_helpers::mock_token_info(plain_owner, plain_owner, "CrcV2_CRC20"),
+    );
+
+    let rewritten = circles_pathfinder::replace_wrapped_tokens_with_avatars(&path, &info_map);
+
+    assert_eq!(
+        rewritten.transfers[0].token_owner,
+        format!("{wrapped_owner:#x}")
+    );
+    assert_eq!(
+        rewritten.transfers[1].token_owner,
+        format!("{plain_owner:#x}")
+    );
+    assert_eq!(rewritten.transfers[0].from, path.transfers[0].from);
+    assert_eq!(rewritten.transfers[0].to, path.transfers[0].to);
+    assert_eq!(rewritten.transfers[0].value, path.transfers[0].value);
+}

--- a/crates/pathfinder/tests/path_wrapper_tests.rs
+++ b/crates/pathfinder/tests/path_wrapper_tests.rs
@@ -69,7 +69,8 @@ fn converts_inflationary_wrapper_totals() {
     info.timestamp = 1_700_000_000;
     info_map.insert(wrapper, info);
 
-    let unwrapped = circles_pathfinder::path::expected_unwrapped_totals(&totals, &info_map);
+    let unwrapped =
+        circles_pathfinder::expected_unwrapped_totals_at(&totals, &info_map, Some(1_700_000_000));
     let (amount, owner) = unwrapped.get(&wrapper).unwrap();
 
     // We expect ~1e18 demurraged amount after conversion back from static for ts=1_700_000_000.

--- a/crates/pathfinder/tests/rpc_tests.rs
+++ b/crates/pathfinder/tests/rpc_tests.rs
@@ -1,5 +1,8 @@
 use alloy_primitives::aliases::U192;
-use circles_pathfinder::{PathfinderError, find_path};
+use circles_pathfinder::{
+    FindPathParams, PathfinderError, find_path, find_path_via_rpc, find_path_with_params_via_rpc,
+};
+use circles_rpc::CirclesRpc;
 
 mod common;
 
@@ -42,6 +45,55 @@ async fn test_find_path_with_invalid_rpc() {
     // Check that it's the right kind of error
     match result.unwrap_err() {
         PathfinderError::Transport(_) => {} // Expected
+        other => panic!("Expected RPC error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_find_path_via_rpc_with_invalid_rpc() {
+    let sender = common::addresses::sender();
+    let receiver = common::addresses::receiver();
+    let value = common::wei_from_str(common::ONE_ETH_WEI);
+    let rpc = CirclesRpc::try_from_http("http://invalid-rpc-url.com").unwrap();
+
+    let result = find_path_via_rpc(&rpc, sender, receiver, value, true).await;
+    assert!(
+        result.is_err(),
+        "Should return error for invalid RPC client"
+    );
+
+    match result.unwrap_err() {
+        PathfinderError::Transport(_) => {}
+        other => panic!("Expected RPC error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_find_path_with_params_via_rpc_with_invalid_rpc() {
+    let sender = common::addresses::sender();
+    let receiver = common::addresses::receiver();
+    let rpc = CirclesRpc::try_from_http("http://invalid-rpc-url.com").unwrap();
+    let params = FindPathParams {
+        from: sender,
+        to: receiver,
+        target_flow: alloy_primitives::U256::from(common::wei_from_str(common::ONE_ETH_WEI)),
+        use_wrapped_balances: Some(true),
+        from_tokens: None,
+        to_tokens: None,
+        exclude_from_tokens: None,
+        exclude_to_tokens: None,
+        simulated_balances: None,
+        max_transfers: None,
+    };
+
+    let result = find_path_with_params_via_rpc(&rpc, params).await;
+    assert!(
+        result.is_err(),
+        "Should return error for invalid RPC client"
+    );
+
+    match result.unwrap_err() {
+        PathfinderError::Transport(_) => {}
         other => panic!("Expected RPC error, got: {other:?}"),
     }
 }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/circles-rpc"
 alloy-json-rpc = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
-alloy-transport-http = "1.1.2"
-alloy-transport-ws = { version = "1.1.2", optional = true }
+alloy-transport-http = { workspace = true }
+alloy-transport-ws = { workspace = true, optional = true }
 circles-types = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/circles-sdk"
 [dependencies]
 alloy-primitives = { workspace = true }
 async-trait = { workspace = true }
-circles-profiles = { path = "../profiles", version = "0.1.0" }
-circles-rpc = { path = "../rpc", version = "0.1.0" }
+circles-profiles = { workspace = true }
+circles-rpc = { workspace = true }
 circles-types = { workspace = true }
-circles-transfers = { path = "../transfers", version = "0.1.0" }
-circles-abis = { path = "../abis", version = "0.1.0" }
+circles-transfers = { workspace = true }
+circles-abis = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
 alloy-provider = { workspace = true }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -1,47 +1,75 @@
 # Circles SDK (Rust)
 
-Rust port of the Circles TypeScript SDK, orchestrating Circles RPC, profiles, pathfinding, transfers, and optional contract runners. Read flows work without a runner; write paths are gated and return `MissingRunner` until you provide one.
+Rust port of the TypeScript Circles SDK. `circles-sdk` is the high-level crate that wires together `circles-rpc`, `circles-profiles`, `circles-pathfinder`, `circles-transfers`, and the generated contract bindings.
 
-## Features
-- Avatar helpers (human/org/group) for balances, trust, profiles, and registration flows.
-- Invitation/referral helpers (generate invites, escrow/redeem checks, send/revoke/list/redeem).
+The usage model is intentionally simple:
+
+- Construct `Sdk` with `None` for read-only flows.
+- Use `get_avatar` when you want a typed wrapper (`HumanAvatar`, `OrganisationAvatar`, `BaseGroupAvatar`).
+- Provide a `ContractRunner` only when you need write paths such as registration, trust updates, or transfer submission.
+
+## Capabilities
+
+- Typed avatar helpers for balances, trust, profiles, pathfinding, transfer planning, and registration flows.
+- Invitation and referral helpers for human avatars.
 - Transfer planning and replenish/max-flow helpers via `circles-transfers` and `circles-pathfinder`.
-- Websocket subscriptions with retry/backoff + optional HTTP catch-up (feature `ws`).
-- Shared config: `config::gnosis_mainnet()` and a `GNOSIS_MAINNET` lazy static.
+- Optional WebSocket subscriptions with retry/backoff and HTTP catch-up through the `ws` feature.
+- Shared mainnet config through `config::gnosis_mainnet()` and `GNOSIS_MAINNET`.
 
-## Quickstart (read-only)
+## Quickstart
 ```rust
-use circles_sdk::{config, Sdk};
 use alloy_primitives::address;
+use circles_sdk::{Avatar, Sdk, config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Gnosis chain (100) mainnet config
-    let sdk = Sdk::new(config::gnosis_mainnet(), None)?; // runner None => read-only
+    let sdk = Sdk::new(config::gnosis_mainnet(), None)?;
     let avatar = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    let info = sdk.avatar_info(avatar).await?;
-    println!("avatar type: {:?}", info.avatar_type);
+
+    match sdk.get_avatar(avatar).await? {
+        Avatar::Human(human) => {
+            let balances = human.balances(false, true).await?;
+            println!("human balances: {}", balances.len());
+        }
+        Avatar::Organisation(org) => {
+            let trust = org.trust_relations().await?;
+            println!("org trust edges: {}", trust.len());
+        }
+        Avatar::Group(group) => {
+            let info = group.profile().await?;
+            println!("group profile loaded: {}", info.is_some());
+        }
+    }
+
     Ok(())
 }
 ```
 
+## Runner Model
+
+All write-capable methods return `SdkError::MissingRunner` until a `ContractRunner` is provided. The SDK keeps read logic separate from transaction submission so Safe, EOAs, or other runner backends can be added without changing the public read API.
+
 ## Examples
-- `basic_read.rs`: fetch avatar info/balances/trust and run a pathfind.
-- `invite_generate.rs`: build invitation secrets/signers and inspect txs.
-- `ws_subscribe.rs` (feature `ws`): subscribe with retries + catch-up.
+
+- `basic_read.rs`: avatar info, balances, trust, and pathfinding.
+- `invite_generate.rs`: invitation secrets/signers plus prepared transactions.
+- `ws_subscribe.rs` with `--features ws`: live events with retries and optional catch-up.
 
 ## Runners
-- Implement `ContractRunner` to enable write paths (registrations, trust ops, transfers). The SDK stays read-only without one and returns `SdkError::MissingRunner`.
-- Runner wiring mirrors the TS SDK; Safe support is deferred for now.
+
+- Implement `ContractRunner` to enable write paths.
+- `PreparedTransaction` is the SDK’s handoff format: target address, calldata, and optional value.
+- Safe-specific support is still deferred; the current API is intentionally generic.
 
 ## Tests
+
 - Unit tests: `cargo test -p circles-sdk`
-- WS helpers: `cargo test -p circles-sdk --features ws`
-- Optional live checks (ignored by default):  
-  `RUN_LIVE=1 LIVE_AVATAR=0x... cargo test -p circles-sdk -- --ignored`  
-  Override endpoints with `CIRCLES_RPC_URL`, `CIRCLES_PATHFINDER_URL`, `CIRCLES_PROFILE_URL`.
+- WS-enabled unit tests: `cargo test -p circles-sdk --features ws`
+- Optional live checks: `RUN_LIVE=1 LIVE_AVATAR=0x... cargo test -p circles-sdk -- --ignored`
+- Override live endpoints with `CIRCLES_RPC_URL`, `CIRCLES_PATHFINDER_URL`, and `CIRCLES_PROFILE_URL`.
 
 ## Notes
-- WS helpers tolerate heartbeats/batches and expose retry/catch-up utilities; reconnect/backoff is handled in `ws` module.
-- Transfer/pathfinding helpers default to using wrapped balances; tune `AdvancedTransferOptions` if you need exclusions or simulated balances.
-- Docs: `cargo doc -p circles-sdk --all-features` for rustdoc output.
+
+- WS helpers tolerate heartbeats and batched frames; unknown event types still surface as regular events from `circles-rpc`.
+- Transfer/pathfinding helpers default to wrapped balances; tune `AdvancedTransferOptions` when you need exclusions or simulated balances.
+- Generate local rustdoc with `cargo doc -p circles-sdk --all-features`.

--- a/crates/sdk/src/avatar/base_group.rs
+++ b/crates/sdk/src/avatar/base_group.rs
@@ -18,10 +18,15 @@ use std::sync::Arc;
 
 /// Top-level avatar enum variant: base group.
 pub struct BaseGroupAvatar {
+    /// Avatar address on-chain.
     pub address: Address,
+    /// RPC-derived avatar metadata.
     pub info: AvatarInfo,
+    /// Shared contract bundle and configuration.
     pub core: Arc<Core>,
+    /// Optional runner used for write-capable flows.
     pub runner: Option<Arc<dyn ContractRunner>>,
+    /// Shared read/write helper implementation.
     pub common: CommonAvatar,
 }
 
@@ -139,6 +144,7 @@ impl BaseGroupAvatar {
         self.common.max_flow_to(to, options).await
     }
 
+    /// Build a typed base-group avatar wrapper from already-fetched components.
     pub fn new(
         address: Address,
         info: AvatarInfo,

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -22,19 +22,28 @@ use std::sync::Arc;
 
 /// Top-level avatar enum variant: human.
 pub struct HumanAvatar {
+    /// Avatar address on-chain.
     pub address: Address,
+    /// RPC-derived avatar metadata.
     pub info: AvatarInfo,
+    /// Shared contract bundle and configuration.
     pub core: Arc<Core>,
+    /// Optional runner used for write-capable flows.
     pub runner: Option<Arc<dyn ContractRunner>>,
+    /// Shared read/write helper implementation.
     pub common: CommonAvatar,
 }
 
 /// Invitation generation result (secrets + signers + prepared txs).
 #[derive(Debug, Clone)]
 pub struct GeneratedInvites {
+    /// Generated invitation secrets in hex form.
     pub secrets: Vec<String>,
+    /// Derived signer addresses associated with the generated secrets.
     pub signers: Vec<Address>,
+    /// Prepared transactions required to mint/fund the invites.
     pub txs: Vec<RunnerTx>,
+    /// Submitted transactions when invite generation was executed through a runner.
     pub submitted: Option<Vec<RunnerSubmitted>>,
 }
 
@@ -161,6 +170,7 @@ impl HumanAvatar {
         self.common.transfer(to, amount, options).await
     }
 
+    /// Find a path from this avatar to `to` for the requested target flow.
     pub async fn find_path(
         &self,
         to: Address,
@@ -170,6 +180,7 @@ impl HumanAvatar {
         self.common.find_path(to, target_flow, options).await
     }
 
+    /// Compute the maximum available flow from this avatar to `to`.
     pub async fn max_flow_to(
         &self,
         to: Address,

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -18,10 +18,15 @@ use std::sync::Arc;
 
 /// Top-level avatar enum variant: organisation.
 pub struct OrganisationAvatar {
+    /// Avatar address on-chain.
     pub address: Address,
+    /// RPC-derived avatar metadata.
     pub info: AvatarInfo,
+    /// Shared contract bundle and configuration.
     pub core: Arc<Core>,
+    /// Optional runner used for write-capable flows.
     pub runner: Option<Arc<dyn ContractRunner>>,
+    /// Shared read/write helper implementation.
     pub common: CommonAvatar,
 }
 
@@ -127,6 +132,7 @@ impl OrganisationAvatar {
         self.common.max_flow_to(to, options).await
     }
 
+    /// Build a typed organisation avatar wrapper from already-fetched components.
     pub fn new(
         address: Address,
         info: AvatarInfo,

--- a/crates/sdk/src/core.rs
+++ b/crates/sdk/src/core.rs
@@ -1,3 +1,8 @@
+//! Internal contract bundle used by the SDK.
+//!
+//! `Core` owns the resolved Circles configuration and constructs lightweight Alloy
+//! contract handles on demand. It is shared by `Sdk` and the typed avatar wrappers.
+
 use alloy_provider::{Identity, ProviderBuilder, RootProvider};
 use circles_abis::{
     BaseGroup, BaseGroupFactory, DemurrageCircles, HubV2, InflationaryCircles, InvitationEscrow,
@@ -12,6 +17,7 @@ pub struct Core {
 }
 
 impl Core {
+    /// Build a new contract bundle from the provided Circles configuration.
     pub fn new(config: CirclesConfig) -> Self {
         Self { config }
     }
@@ -26,18 +32,22 @@ impl Core {
         )
     }
 
+    /// Hub v2 contract instance bound to the configured v2 hub address.
     pub fn hub_v2(&self) -> HubV2::HubV2Instance<RootProvider> {
         HubV2::new(self.config.v2_hub_address, self.provider())
     }
 
+    /// Name registry contract instance.
     pub fn name_registry(&self) -> NameRegistry::NameRegistryInstance<RootProvider> {
         NameRegistry::new(self.config.name_registry_address, self.provider())
     }
 
+    /// Base group factory contract instance.
     pub fn base_group_factory(&self) -> BaseGroupFactory::BaseGroupFactoryInstance<RootProvider> {
         BaseGroupFactory::new(self.config.base_group_factory_address, self.provider())
     }
 
+    /// Base group contract instance for an already-known group address.
     pub fn base_group(
         &self,
         address: alloy_primitives::Address,
@@ -45,28 +55,34 @@ impl Core {
         BaseGroup::new(address, self.provider())
     }
 
+    /// Invitation escrow contract instance.
     pub fn invitation_escrow(&self) -> InvitationEscrow::InvitationEscrowInstance<RootProvider> {
         InvitationEscrow::new(self.config.invitation_escrow_address, self.provider())
     }
 
+    /// Invitation farm contract instance.
     pub fn invitation_farm(&self) -> InvitationFarm::InvitationFarmInstance<RootProvider> {
         InvitationFarm::new(self.config.invitation_farm_address, self.provider())
     }
 
+    /// LiftERC20 helper contract instance.
     pub fn lift_erc20(&self) -> LiftERC20::LiftERC20Instance<RootProvider> {
         LiftERC20::new(self.config.lift_erc20_address, self.provider())
     }
 
+    /// Demurraged Circles token contract handle.
     pub fn demurrage_circles(&self) -> DemurrageCircles::DemurrageCirclesInstance<RootProvider> {
         DemurrageCircles::new(self.config.v2_hub_address, self.provider())
     }
 
+    /// Inflationary Circles token contract handle.
     pub fn inflationary_circles(
         &self,
     ) -> InflationaryCircles::InflationaryCirclesInstance<RootProvider> {
         InflationaryCircles::new(self.config.v2_hub_address, self.provider())
     }
 
+    /// Referrals module contract instance.
     pub fn referrals_module(&self) -> ReferralsModule::ReferralsModuleInstance<RootProvider> {
         ReferralsModule::new(self.config.referrals_module_address, self.provider())
     }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -1,6 +1,56 @@
-//! Circles SDK (Rust) — orchestrates RPC, profiles, and contract interactions.
-//! Minimal scaffold mirroring the TypeScript SDK shape with read-only flows first
-//! and write paths gated behind a `ContractRunner`.
+//! Circles SDK orchestrating RPC, profile service access, pathfinding, transfers,
+//! and optional contract execution.
+//!
+//! This crate mirrors the high-level TypeScript SDK shape while keeping the Rust
+//! implementation read-first: most reads work with `Sdk::new(config, None)`, and
+//! write paths are gated behind a [`ContractRunner`].
+//!
+//! ## Quick Start
+//!
+//! ```rust,no_run
+//! use alloy_primitives::address;
+//! use circles_sdk::{Sdk, config};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let sdk = Sdk::new(config::gnosis_mainnet(), None)?;
+//! let avatar = address!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+//! let info = sdk.avatar_info(avatar).await?;
+//! println!("avatar type: {:?}", info.avatar_type);
+//!
+//! let typed = sdk.get_avatar(avatar).await?;
+//! match typed {
+//!     circles_sdk::Avatar::Human(human) => {
+//!         let balances = human.balances(false, true).await?;
+//!         println!("balances: {}", balances.len());
+//!     }
+//!     circles_sdk::Avatar::Organisation(_) | circles_sdk::Avatar::Group(_) => {}
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Usage Model
+//!
+//! - [`Sdk`] wires together RPC, profile lookups, pathfinding, transfers, and contract bindings.
+//! - [`Avatar`] gives you a typed wrapper after runtime avatar detection.
+//! - [`ContractRunner`] is only required for write paths such as registrations, trust changes,
+//!   and transfer submission.
+//! - The optional `ws` feature enables WebSocket subscriptions with retry/backoff and HTTP catch-up helpers.
+//!
+//! ## Recommended Entry Points
+//!
+//! - [`config::gnosis_mainnet`] for the shared mainnet configuration.
+//! - [`Sdk::avatar_info`] for a fast read-only probe.
+//! - [`Sdk::get_avatar`] when you want a typed avatar wrapper.
+//! - [`HumanAvatar::plan_transfer`], [`OrganisationAvatar::plan_transfer`], and
+//!   [`BaseGroupAvatar::plan_transfer`] for transaction planning before submission.
+//!
+//! ## Validation
+//!
+//! - Unit tests: `cargo test -p circles-sdk`
+//! - WS helpers: `cargo test -p circles-sdk --features ws`
+//! - Live checks (ignored by default): `RUN_LIVE=1 LIVE_AVATAR=0x... cargo test -p circles-sdk -- --ignored`
 
 mod avatar;
 mod cid_v0_to_digest;
@@ -34,7 +84,9 @@ use thiserror::Error;
 ///
 /// Registration helpers may return prepared txs without sending if no runner is provided.
 pub struct RegistrationResult<T> {
+    /// Best-effort typed avatar returned after registration succeeds.
     pub avatar: Option<T>,
+    /// Submitted transactions returned by the runner.
     pub txs: Vec<SubmittedTx>,
 }
 
@@ -64,6 +116,8 @@ pub enum SdkError {
 }
 
 /// Top-level SDK orchestrator.
+///
+/// Construct this once per config/runner pair and reuse it across read and write flows.
 pub struct Sdk {
     pub(crate) config: CirclesConfig,
     pub(crate) rpc: Arc<CirclesRpc>,
@@ -123,7 +177,9 @@ impl Sdk {
         self.sender_address
     }
 
-    /// Create and pin a profile via the profile service (runner not required).
+    /// Create and pin a profile via the profile service.
+    ///
+    /// This only talks to the profile service and does not submit any on-chain transaction.
     pub async fn create_profile(&self, profile: &Profile) -> Result<String, SdkError> {
         Ok(self.profiles.create(profile).await?)
     }
@@ -133,15 +189,20 @@ impl Sdk {
         Ok(self.profiles.get(cid).await?)
     }
 
-    /// Basic data helpers (read-only).
+    /// Read avatar metadata directly from the RPC service.
     pub async fn data_avatar(&self, avatar: Address) -> Result<AvatarInfo, SdkError> {
         Ok(self.rpc.avatar().get_avatar_info(avatar).await?)
     }
 
+    /// Read trust relations for an avatar directly from the RPC service.
     pub async fn data_trust(&self, avatar: Address) -> Result<Vec<TrustRelation>, SdkError> {
         Ok(self.rpc.trust().get_trust_relations(avatar).await?)
     }
 
+    /// Read token balances for an avatar directly from the RPC service.
+    ///
+    /// Set `as_time_circles` to request balances in time-Circles units and `use_v2`
+    /// to scope the query to v2 balances.
     pub async fn data_balances(
         &self,
         avatar: Address,
@@ -160,7 +221,7 @@ impl Sdk {
         Ok(self.rpc.avatar().get_avatar_info(avatar).await?)
     }
 
-    /// Subscribe to Circles events over websocket with a custom filter.
+    /// Subscribe to Circles events over WebSocket with a custom JSON-RPC filter payload.
     #[cfg(feature = "ws")]
     pub async fn subscribe_events_ws<F>(
         &self,
@@ -178,7 +239,7 @@ impl Sdk {
             .await
     }
 
-    /// Subscribe with retry/backoff on websocket disconnects.
+    /// Subscribe with retry/backoff on WebSocket connection or subscription failure.
     #[cfg(feature = "ws")]
     pub async fn subscribe_events_ws_with_retries(
         &self,
@@ -189,7 +250,7 @@ impl Sdk {
         ws::subscribe_with_retries(ws_url, filter, max_attempts).await
     }
 
-    /// Subscribe with retry/backoff and optional HTTP catch-up.
+    /// Subscribe with retry/backoff and optionally fetch historical events first over HTTP.
     #[cfg(feature = "ws")]
     pub async fn subscribe_events_ws_with_catchup(
         &self,
@@ -211,7 +272,10 @@ impl Sdk {
         .await
     }
 
-    /// Fetch avatar info and return a typed avatar wrapper.
+    /// Fetch avatar info and return the matching typed avatar wrapper.
+    ///
+    /// Unknown or personal avatar types are treated as [`Avatar::Human`] to match the
+    /// current SDK behavior.
     pub async fn get_avatar(&self, avatar: Address) -> Result<Avatar, SdkError> {
         let info = self.rpc.avatar().get_avatar_info(avatar).await?;
         Ok(match info.avatar_type {
@@ -288,7 +352,10 @@ impl Sdk {
 
 /// Top-level avatar enum (human, organisation, group).
 pub enum Avatar {
+    /// Human or personal avatar wrapper.
     Human(HumanAvatar),
+    /// Organisation avatar wrapper.
     Organisation(OrganisationAvatar),
+    /// Base group avatar wrapper.
     Group(BaseGroupAvatar),
 }

--- a/crates/sdk/src/runner.rs
+++ b/crates/sdk/src/runner.rs
@@ -1,3 +1,9 @@
+//! Runner abstractions for write-capable SDK flows.
+//!
+//! The SDK prepares transactions as ABI-encoded calls and delegates submission to
+//! an implementation of [`ContractRunner`]. This keeps the read path independent
+//! from any wallet, Safe, or signer transport.
+
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::SolCall;
 use async_trait::async_trait;
@@ -7,8 +13,11 @@ use thiserror::Error;
 /// we can swap to richer contract-specific types as we wire more flows.
 #[derive(Debug, Clone)]
 pub struct PreparedTransaction {
+    /// Contract address to call.
     pub to: Address,
+    /// ABI-encoded calldata.
     pub data: Bytes,
+    /// Optional native value to send alongside the call.
     pub value: Option<U256>,
 }
 
@@ -24,6 +33,7 @@ pub fn call_to_tx<C: SolCall>(to: Address, call: C, value: Option<U256>) -> Prep
 /// Result stub for submitted transactions. Will be expanded when wiring a Safe runner.
 #[derive(Debug, Clone)]
 pub struct SubmittedTx {
+    /// Runner-reported transaction hash bytes.
     pub tx_hash: Bytes,
 }
 

--- a/crates/sdk/src/ws.rs
+++ b/crates/sdk/src/ws.rs
@@ -1,3 +1,8 @@
+//! WebSocket helpers for SDK event subscriptions.
+//!
+//! These functions sit on top of `circles-rpc` and provide the light retry/catch-up
+//! behavior used by the SDK public API.
+
 use crate::SdkError;
 use circles_rpc::{CirclesRpc, events::subscription::CirclesSubscription};
 use circles_types::{CirclesEvent, Filter};
@@ -47,7 +52,10 @@ pub async fn subscribe_with_retries(
     }
 }
 
-/// Fetch historical events (HTTP) then subscribe live (WS).
+/// Fetch historical events over HTTP and then start a live WebSocket subscription.
+///
+/// If `catch_up_from_block` is `None`, the returned event list is empty and only the
+/// live subscription is started.
 pub async fn subscribe_with_catchup(
     rpc: &CirclesRpc,
     ws_url: &str,
@@ -68,7 +76,10 @@ pub async fn subscribe_with_catchup(
     Ok((catch_up_events, sub))
 }
 
-/// Spawn a handler over a subscription; errors are logged via tracing at warn.
+/// Spawn a background handler for a live event subscription.
+///
+/// Stream errors are logged at `warn` and do not stop the task from receiving
+/// later items.
 pub fn spawn_event_handler<H>(
     mut sub: CirclesSubscription<CirclesEvent>,
     handler: H,

--- a/crates/transfers/Cargo.toml
+++ b/crates/transfers/Cargo.toml
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/circles-transfers"
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
 alloy-sol-types = { workspace = true }
-circles-abis = { path = "../abis", version = "0.1.0" }
-circles-rpc = { path = "../rpc", version = "0.1.0" }
-circles-pathfinder = { path = "../pathfinder", version = "0.5.0" }
+circles-abis = { workspace = true }
+circles-rpc = { workspace = true }
+circles-pathfinder = { workspace = true }
 circles-types = { workspace = true }
-circles-utils = { path = "../utils", version = "0.1.0" }
+circles-utils = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/transfers/README.md
+++ b/crates/transfers/README.md
@@ -6,6 +6,7 @@ Builder for Circles transfer transactions (port of TS `@aboutcircles/sdk-transfe
 - Builds approval → unwraps → `operateFlowMatrix` → inflationary re-wrap leftovers.
 - Handles demurraged and inflationary wrappers. Inflationary unwrap uses static amounts; leftover re-wrap uses `staticAttoCircles` from `circles_getTokenBalances`.
 - Self-transfer fast-path resolves wrapper type via LiftERC20; approval inclusion is configurable.
+- Includes an aggregate-capable entrypoint that mirrors the TS recipient self-transfer behavior when `to_tokens` selects exactly one token.
 - Fixtures cover demurraged-only, mixed wrappers (with rewrap), and a no-leftover inflationary case (static balance forced to zero for now).
 
 ## Usage

--- a/crates/transfers/src/builder.rs
+++ b/crates/transfers/src/builder.rs
@@ -8,7 +8,8 @@ use circles_pathfinder::{
 };
 use circles_rpc::CirclesRpc;
 use circles_types::{
-    AdvancedTransferOptions, CirclesConfig, FindPathParams, TokenBalanceResponse, TransferStep,
+    AdvancedTransferOptions, CirclesConfig, FindPathParams, PathfindingTransferStep,
+    TokenBalanceResponse, TransferStep,
 };
 use circles_utils::converter::atto_circles_to_atto_static_circles;
 use std::collections::HashMap;
@@ -80,6 +81,20 @@ impl TransferBuilder {
         amount: U256,
         options: Option<AdvancedTransferOptions>,
     ) -> Result<Vec<TransferTx>, TransferError> {
+        self.construct_advanced_transfer_with_aggregate(from, to, amount, options, false)
+            .await
+    }
+
+    /// Construct an advanced transfer and optionally append the TS-style
+    /// recipient aggregation self-transfer when a single `to_token` is selected.
+    pub async fn construct_advanced_transfer_with_aggregate(
+        &self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        options: Option<AdvancedTransferOptions>,
+        aggregate: bool,
+    ) -> Result<Vec<TransferTx>, TransferError> {
         // Self-transfer fast-path for unwrap: if from == to and from/to tokens are provided and distinct.
         if from == to {
             if let Some(ref opts) = options {
@@ -148,6 +163,8 @@ impl TransferBuilder {
                 to,
             ));
         }
+
+        let path = maybe_add_aggregate_transfer(path, to, &opts, aggregate);
 
         // Token info + wrapper bookkeeping
         let token_info_map = token_info_map_from_path(from, &self.rpc, &path)
@@ -408,6 +425,28 @@ fn validate_wrapped_balance_usage(
     Ok(())
 }
 
+fn maybe_add_aggregate_transfer(
+    mut path: circles_types::PathfindingResult,
+    to: Address,
+    opts: &AdvancedTransferOptions,
+    aggregate: bool,
+) -> circles_types::PathfindingResult {
+    let Some(to_tokens) = opts.to_tokens.as_ref() else {
+        return path;
+    };
+
+    if aggregate && to_tokens.len() == 1 && path.max_flow > U256::ZERO {
+        path.transfers.push(PathfindingTransferStep {
+            from: to,
+            to,
+            token_owner: format!("{:#x}", to_tokens[0]),
+            value: path.max_flow,
+        });
+    }
+
+    path
+}
+
 impl TransferBuilder {
     async fn needs_approval(&self, operator: Address) -> Option<bool> {
         let Ok(url) = self.config.circles_rpc_url.parse() else {
@@ -493,8 +532,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::validate_wrapped_balance_usage;
+    use super::{maybe_add_aggregate_transfer, validate_wrapped_balance_usage};
     use crate::TransferError;
+    use alloy_primitives::{address, U256};
+    use circles_types::{AdvancedTransferOptions, PathfindingResult, PathfindingTransferStep};
 
     #[test]
     fn wrapped_balance_guard_matches_ts_behavior() {
@@ -508,5 +549,72 @@ mod tests {
             validate_wrapped_balance_usage(true, None),
             Err(TransferError::WrappedTokensRequired)
         ));
+    }
+
+    #[test]
+    fn aggregate_transfer_is_appended_for_single_to_token() {
+        let source = address!("0x1000000000000000000000000000000000000001");
+        let sink = address!("0x2000000000000000000000000000000000000002");
+        let aggregate_token = address!("0x3000000000000000000000000000000000000003");
+        let path = PathfindingResult {
+            max_flow: U256::from(5u64),
+            transfers: vec![PathfindingTransferStep {
+                from: source,
+                to: sink,
+                token_owner: format!("{source:#x}"),
+                value: U256::from(5u64),
+            }],
+        };
+        let opts = AdvancedTransferOptions {
+            use_wrapped_balances: Some(true),
+            from_tokens: None,
+            to_tokens: Some(vec![aggregate_token]),
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            max_transfers: None,
+            tx_data: None,
+        };
+
+        let aggregated = maybe_add_aggregate_transfer(path, sink, &opts, true);
+        let appended = aggregated.transfers.last().unwrap();
+
+        assert_eq!(aggregated.transfers.len(), 2);
+        assert_eq!(appended.from, sink);
+        assert_eq!(appended.to, sink);
+        assert_eq!(appended.token_owner, format!("{aggregate_token:#x}"));
+        assert_eq!(appended.value, U256::from(5u64));
+    }
+
+    #[test]
+    fn aggregate_transfer_is_not_appended_without_single_to_token() {
+        let source = address!("0x4000000000000000000000000000000000000004");
+        let sink = address!("0x5000000000000000000000000000000000000005");
+        let path = PathfindingResult {
+            max_flow: U256::from(5u64),
+            transfers: vec![PathfindingTransferStep {
+                from: source,
+                to: sink,
+                token_owner: format!("{source:#x}"),
+                value: U256::from(5u64),
+            }],
+        };
+        let opts = AdvancedTransferOptions {
+            use_wrapped_balances: Some(true),
+            from_tokens: None,
+            to_tokens: Some(vec![
+                address!("0x6000000000000000000000000000000000000006"),
+                address!("0x7000000000000000000000000000000000000007"),
+            ]),
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            max_transfers: None,
+            tx_data: None,
+        };
+
+        let unchanged = maybe_add_aggregate_transfer(path, sink, &opts, true);
+
+        assert_eq!(unchanged.transfers.len(), 1);
     }
 }

--- a/crates/transfers/src/builder.rs
+++ b/crates/transfers/src/builder.rs
@@ -162,9 +162,7 @@ impl TransferBuilder {
         let wrapped_totals = wrapped_totals_from_path(&path, &token_info_map);
         let has_wrapped = !wrapped_totals.is_empty();
 
-        if has_wrapped && opts.use_wrapped_balances.unwrap_or(false) {
-            return Err(TransferError::wrapped_tokens_required());
-        }
+        validate_wrapped_balance_usage(has_wrapped, opts.use_wrapped_balances)?;
 
         // Fetch balances once (for inflationary leftover wrap).
         let balance_map = if has_wrapped {
@@ -400,6 +398,16 @@ fn u256_to_u192_local(value: U256) -> alloy_primitives::aliases::U192 {
     }
 }
 
+fn validate_wrapped_balance_usage(
+    has_wrapped: bool,
+    use_wrapped_balances: Option<bool>,
+) -> Result<(), TransferError> {
+    if has_wrapped && !use_wrapped_balances.unwrap_or(false) {
+        return Err(TransferError::wrapped_tokens_required());
+    }
+    Ok(())
+}
+
 impl TransferBuilder {
     async fn needs_approval(&self, operator: Address) -> Option<bool> {
         let Ok(url) = self.config.circles_rpc_url.parse() else {
@@ -481,4 +489,24 @@ where
     Fut: std::future::Future<Output = Option<bool>>,
 {
     futures::executor::block_on(f())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_wrapped_balance_usage;
+    use crate::TransferError;
+
+    #[test]
+    fn wrapped_balance_guard_matches_ts_behavior() {
+        assert!(validate_wrapped_balance_usage(true, Some(true)).is_ok());
+        assert!(validate_wrapped_balance_usage(false, Some(false)).is_ok());
+        assert!(matches!(
+            validate_wrapped_balance_usage(true, Some(false)),
+            Err(TransferError::WrappedTokensRequired)
+        ));
+        assert!(matches!(
+            validate_wrapped_balance_usage(true, None),
+            Err(TransferError::WrappedTokensRequired)
+        ));
+    }
 }

--- a/crates/transfers/src/builder.rs
+++ b/crates/transfers/src/builder.rs
@@ -215,13 +215,9 @@ impl TransferBuilder {
                         value: U256::ZERO,
                     });
                 } else if info.token_type == "CrcV2_ERC20WrapperDeployed_Inflationary" {
-                    // Unwrap only the amount used in the path, converted to static
-                    let ts_hint = if info.timestamp > 0 {
-                        Some(info.timestamp)
-                    } else {
-                        None
-                    };
-                    let static_amt = atto_circles_to_atto_static_circles(*amount_dem, ts_hint);
+                    // Unwrap only the amount used in the path, converted with
+                    // current-time semantics to match the TS TransferBuilder.
+                    let static_amt = atto_circles_to_atto_static_circles(*amount_dem, None);
                     let call = InflationaryCircles::unwrapCall {
                         _amount: static_amt,
                     };

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://circles-rs-book.vercel.app/"
 documentation = "https://docs.rs/circles-types"
 
 [dependencies]
-alloy-json-abi = "1.4.1"
+alloy-json-abi = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
-alloy-rpc-types = "1.1.2"
+alloy-rpc-types = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

- align pathfinder helper behavior and flow-matrix handling with the TypeScript SDK
- add explicit `CirclesRpc` and token-info helper entrypoints, plus deterministic netted-flow helper coverage
- fix transfer-builder wrapped-balance behavior and add the aggregate transfer path
- include the supporting workspace dependency alignment and docs/rustdoc cleanup completed on this branch

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo clippy --workspace --all-targets`
- `cargo test`