### PR TITLE
feat: expand sdk convenience parity surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ As of March 26, 2026, this workspace is closer to the TypeScript SDK, but it is 
 | `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place and is already used by the higher-level crates. |
 | `circles-pathfinder` | Close | Recent parity work aligned flow-matrix terminal edges, wrapped-token rewriting, token-info helpers, netted-flow helpers, and explicit RPC/client entrypoints. |
 | `circles-transfers` | Close | Advanced transfer planning, aggregate transfers, and the TS-style `constructReplenish` flow are present; remaining work is mostly higher-level parity polish and broader behavioral coverage. |
-| `circles-sdk` | Partial | Read flows and typed avatars are usable, and replenish planning/execution now rides the runner abstraction; higher-level convenience parity and wallet-backend parity are still incomplete. |
+| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, profile metadata / short-name writes, personal minting, max-replenish helpers, and base-group write helpers; direct-transfer/history/group-token facade parity and wallet-backend parity are still incomplete. |
 | `circles-profiles`, `circles-utils`, `circles-types`, `circles-abis` | Supporting / lower risk | These crates are in service for the current SDK flows and are not the main parity bottlenecks right now. |
 
-The biggest remaining parity work is no longer the replenish planner itself. The open gaps are broader SDK convenience coverage and execution-backend parity, especially for wallet-specific flows outside the generic runner abstraction.
+The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially TS-style direct transfer/history/group-token helpers and wallet-specific flows outside the generic runner abstraction.
 
 ## Usage model
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ As of March 26, 2026, this workspace is closer to the TypeScript SDK, but it is 
 | `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place and is already used by the higher-level crates. |
 | `circles-pathfinder` | Close | Recent parity work aligned flow-matrix terminal edges, wrapped-token rewriting, token-info helpers, netted-flow helpers, and explicit RPC/client entrypoints. |
 | `circles-transfers` | Close | Advanced transfer planning, aggregate transfers, and the TS-style `constructReplenish` flow are present; remaining work is mostly higher-level parity polish and broader behavioral coverage. |
-| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, profile metadata / short-name writes, personal minting, max-replenish helpers, and base-group write helpers; direct-transfer/history/group-token facade parity and wallet-backend parity are still incomplete. |
+| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, profile metadata / short-name writes, personal minting, max-replenish helpers, base-group read/write helpers, and group-token mint/property helpers; direct-transfer/history/full group-token parity and wallet-backend parity are still incomplete. |
 | `circles-profiles`, `circles-utils`, `circles-types`, `circles-abis` | Supporting / lower risk | These crates are in service for the current SDK flows and are not the main parity bottlenecks right now. |
 
-The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially TS-style direct transfer/history/group-token helpers and wallet-specific flows outside the generic runner abstraction.
+The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially TS-style direct transfer/history helpers, full group-token redeem/group-membership parity, and wallet-specific flows outside the generic runner abstraction.
 
 ## Usage model
 

--- a/crates/rpc/src/methods/trust.rs
+++ b/crates/rpc/src/methods/trust.rs
@@ -1,6 +1,6 @@
 use crate::client::RpcClient;
 use crate::error::Result;
-use circles_types::{Address, TrustRelation, TrustRelationType};
+use circles_types::{Address, AggregatedTrustRelation, TrustRelation, TrustRelationType};
 
 /// Methods for trust relation queries.
 ///
@@ -23,6 +23,16 @@ impl TrustMethods {
             .await
     }
 
+    /// circles_getAggregatedTrustRelations
+    pub async fn get_aggregated_trust_relations(
+        &self,
+        avatar: Address,
+    ) -> Result<Vec<AggregatedTrustRelation>> {
+        self.client
+            .call("circles_getAggregatedTrustRelations", (avatar,))
+            .await
+    }
+
     /// circles_getCommonTrust
     pub async fn get_common_trust(
         &self,
@@ -32,5 +42,32 @@ impl TrustMethods {
         self.client
             .call("circles_getCommonTrust", (avatar_a, avatar_b))
             .await
+    }
+
+    /// Filter aggregated relations to only the avatars that trust `avatar`.
+    pub async fn get_trusted_by(&self, avatar: Address) -> Result<Vec<AggregatedTrustRelation>> {
+        let relations = self.get_aggregated_trust_relations(avatar).await?;
+        Ok(relations
+            .into_iter()
+            .filter(|rel| matches!(rel.relation, TrustRelationType::TrustedBy))
+            .collect())
+    }
+
+    /// Filter aggregated relations to only the avatars trusted by `avatar`.
+    pub async fn get_trusts(&self, avatar: Address) -> Result<Vec<AggregatedTrustRelation>> {
+        let relations = self.get_aggregated_trust_relations(avatar).await?;
+        Ok(relations
+            .into_iter()
+            .filter(|rel| matches!(rel.relation, TrustRelationType::Trusts))
+            .collect())
+    }
+
+    /// Filter aggregated relations to mutual trust edges only.
+    pub async fn get_mutual_trusts(&self, avatar: Address) -> Result<Vec<AggregatedTrustRelation>> {
+        let relations = self.get_aggregated_trust_relations(avatar).await?;
+        Ok(relations
+            .into_iter()
+            .filter(|rel| matches!(rel.relation, TrustRelationType::MutuallyTrusts))
+            .collect())
     }
 }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -13,7 +13,8 @@ The usage model is intentionally simple:
 - Typed avatar helpers for balances, aggregated trust, profiles, pathfinding, transfer planning, replenish planning, and registration flows.
 - Invitation and referral helpers for human avatars.
 - Profile metadata / short-name write helpers plus personal minting for human avatars.
-- Base-group trust/property write helpers (`trust_add_batch_with_conditions`, `set_owner`, `set_service`, `set_fee_collection`, `set_membership_condition`).
+- Base-group trust/property helpers (`owner`, `mint_handler`, `service`, `fee_collection`, `membership_conditions`, `trust_add_batch_with_conditions`, `set_owner`, `set_service`, `set_fee_collection`, `set_membership_condition`).
+- Human and organisation group-token mint/property helpers (`plan_group_token_mint`, `mint_group_token`, `max_group_token_mintable`, plus group owner/treasury/mint-handler/service/fee-collection lookups).
 - Transfer planning and replenish/max-flow helpers via `circles-transfers` and `circles-pathfinder`.
 - Optional WebSocket subscriptions with retry/backoff and HTTP catch-up through the `ws` feature.
 - Shared mainnet config through `config::gnosis_mainnet()` and `GNOSIS_MAINNET`.
@@ -76,4 +77,5 @@ All write-capable methods return `SdkError::MissingRunner` until a `ContractRunn
 - Transfer/pathfinding helpers default to wrapped balances; tune `AdvancedTransferOptions` when you need exclusions or simulated balances/trust edges.
 - Avatar wrappers expose `total_balance`, aggregated trust helpers, and `plan_replenish` / `replenish`; human and organisation avatars also expose `max_replenishable` plus `plan_replenish_max` / `replenish_max`.
 - The SDK still uses flatter Rust methods instead of the TS object namespaces (`balances.*`, `trust.*`, `groupToken.*`), so some convenience parity remains outstanding even where the underlying capability now exists.
+- The main remaining facade gaps are direct-transfer/history helpers, group-token redeem/group-membership convenience methods, and the richer TS invitation surface.
 - Generate local rustdoc with `cargo doc -p circles-sdk --all-features`.

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -10,8 +10,10 @@ The usage model is intentionally simple:
 
 ## Capabilities
 
-- Typed avatar helpers for balances, trust, profiles, pathfinding, transfer planning, and registration flows.
+- Typed avatar helpers for balances, aggregated trust, profiles, pathfinding, transfer planning, replenish planning, and registration flows.
 - Invitation and referral helpers for human avatars.
+- Profile metadata / short-name write helpers plus personal minting for human avatars.
+- Base-group trust/property write helpers (`trust_add_batch_with_conditions`, `set_owner`, `set_service`, `set_fee_collection`, `set_membership_condition`).
 - Transfer planning and replenish/max-flow helpers via `circles-transfers` and `circles-pathfinder`.
 - Optional WebSocket subscriptions with retry/backoff and HTTP catch-up through the `ws` feature.
 - Shared mainnet config through `config::gnosis_mainnet()` and `GNOSIS_MAINNET`.
@@ -32,8 +34,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("human balances: {}", balances.len());
         }
         Avatar::Organisation(org) => {
-            let trust = org.trust_relations().await?;
-            println!("org trust edges: {}", trust.len());
+            let trust = org.aggregated_trust_relations().await?;
+            println!("org trust counterparts: {}", trust.len());
         }
         Avatar::Group(group) => {
             let info = group.profile().await?;
@@ -72,5 +74,6 @@ All write-capable methods return `SdkError::MissingRunner` until a `ContractRunn
 
 - WS helpers tolerate heartbeats and batched frames; unknown event types still surface as regular events from `circles-rpc`.
 - Transfer/pathfinding helpers default to wrapped balances; tune `AdvancedTransferOptions` when you need exclusions or simulated balances/trust edges.
-- Avatar wrappers expose `plan_replenish` / `replenish` alongside the existing transfer helpers.
+- Avatar wrappers expose `total_balance`, aggregated trust helpers, and `plan_replenish` / `replenish`; human and organisation avatars also expose `max_replenishable` plus `plan_replenish_max` / `replenish_max`.
+- The SDK still uses flatter Rust methods instead of the TS object namespaces (`balances.*`, `trust.*`, `groupToken.*`), so some convenience parity remains outstanding even where the underlying capability now exists.
 - Generate local rustdoc with `cargo doc -p circles-sdk --all-features`.

--- a/crates/sdk/src/avatar/base_group.rs
+++ b/crates/sdk/src/avatar/base_group.rs
@@ -12,7 +12,8 @@ use circles_rpc::events::subscription::CirclesSubscription;
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
-    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+    AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
+    TokenBalanceResponse, TrustRelation,
 };
 use std::sync::Arc;
 
@@ -40,9 +41,50 @@ impl BaseGroupAvatar {
         self.common.balances(as_time_circles, use_v2).await
     }
 
+    /// Get aggregate balance (v1/v2 selectable).
+    pub async fn total_balance(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Balance, SdkError> {
+        self.common.total_balance(as_time_circles, use_v2).await
+    }
+
     /// Get trust relations.
     pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
         self.common.trust_relations().await
+    }
+
+    /// Get aggregated trust relations.
+    pub async fn aggregated_trust_relations(
+        &self,
+    ) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.aggregated_trust_relations().await
+    }
+
+    /// Get outgoing trust relations only.
+    pub async fn trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusts().await
+    }
+
+    /// Get incoming trust relations only.
+    pub async fn trusted_by(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusted_by().await
+    }
+
+    /// Get mutual trust relations only.
+    pub async fn mutual_trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.mutual_trusts().await
+    }
+
+    /// Check whether this avatar trusts `other_avatar`.
+    pub async fn is_trusting(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusting(other_avatar).await
+    }
+
+    /// Check whether `other_avatar` trusts this avatar.
+    pub async fn is_trusted_by(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusted_by(other_avatar).await
     }
 
     /// Fetch profile (cached by CID in memory).
@@ -53,9 +95,23 @@ impl BaseGroupAvatar {
     /// Update profile metadata digest on the base group (requires runner).
     pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
         let cid = self.common.pin_profile(profile).await?;
-        let digest = cid_v0_to_digest(&cid)?;
+        self.update_profile_metadata(&cid).await
+    }
+
+    /// Update the on-chain profile CID pointer through the BaseGroup contract (requires runner).
+    pub async fn update_profile_metadata(&self, cid: &str) -> Result<Vec<SubmittedTx>, SdkError> {
+        let digest = cid_v0_to_digest(cid)?;
         let call = circles_abis::BaseGroup::updateMetadataDigestCall {
             _metadataDigest: digest,
+        };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Register a short name using a specific nonce (requires runner).
+    pub async fn register_short_name(&self, nonce: u64) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = circles_abis::BaseGroup::registerShortNameWithNonceCall {
+            _nonce: U256::from(nonce),
         };
         let tx = call_to_tx(self.address, call, None);
         self.common.send(vec![tx]).await
@@ -82,6 +138,60 @@ impl BaseGroupAvatar {
     /// Remove trust (sets expiry to 0). Requires runner.
     pub async fn trust_remove(&self, avatars: &[Address]) -> Result<Vec<SubmittedTx>, SdkError> {
         self.trust_add(avatars, 0).await
+    }
+
+    /// Trust a batch of members with membership condition checks (requires runner).
+    pub async fn trust_add_batch_with_conditions(
+        &self,
+        avatars: &[Address],
+        expiry: u128,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = BaseGroup::trustBatchWithConditionsCall {
+            _members: avatars.to_vec(),
+            _expiry: U96::from(expiry),
+        };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Set a new owner for the group (requires runner).
+    pub async fn set_owner(&self, owner: Address) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = BaseGroup::setOwnerCall { _owner: owner };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Set a new service address for the group (requires runner).
+    pub async fn set_service(&self, service: Address) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = BaseGroup::setServiceCall { _service: service };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Set a new fee collection address for the group (requires runner).
+    pub async fn set_fee_collection(
+        &self,
+        fee_collection: Address,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = BaseGroup::setFeeCollectionCall {
+            _feeCollection: fee_collection,
+        };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Enable or disable a membership condition (requires runner).
+    pub async fn set_membership_condition(
+        &self,
+        condition: Address,
+        enabled: bool,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = BaseGroup::setMembershipConditionCall {
+            _condition: condition,
+            _enabled: enabled,
+        };
+        let tx = call_to_tx(self.address, call, None);
+        self.common.send(vec![tx]).await
     }
 
     #[cfg(feature = "ws")]
@@ -181,5 +291,186 @@ impl BaseGroupAvatar {
             runner,
             common,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, TxHash};
+    use alloy_sol_types::SolCall;
+    use async_trait::async_trait;
+    use circles_profiles::Profiles;
+    use circles_types::{AvatarType, CirclesConfig};
+    use std::sync::Mutex;
+
+    const TEST_CID: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        sender: Address,
+        sent: Mutex<Vec<Vec<PreparedTransaction>>>,
+    }
+
+    #[async_trait]
+    impl ContractRunner for RecordingRunner {
+        fn sender_address(&self) -> Address {
+            self.sender
+        }
+
+        async fn send_transactions(
+            &self,
+            txs: Vec<PreparedTransaction>,
+        ) -> Result<Vec<crate::SubmittedTx>, crate::RunnerError> {
+            self.sent.lock().expect("lock").push(txs.clone());
+            Ok(txs
+                .into_iter()
+                .map(|_| crate::SubmittedTx {
+                    tx_hash: Bytes::from(TxHash::ZERO.as_slice().to_vec()),
+                })
+                .collect())
+        }
+    }
+
+    fn dummy_config() -> CirclesConfig {
+        CirclesConfig {
+            circles_rpc_url: "https://rpc.example.com".into(),
+            pathfinder_url: "https://pathfinder.example.com".into(),
+            profile_service_url: "https://profiles.example.com".into(),
+            v1_hub_address: Address::repeat_byte(0x01),
+            v2_hub_address: Address::repeat_byte(0x02),
+            name_registry_address: Address::repeat_byte(0x03),
+            base_group_mint_policy: Address::repeat_byte(0x04),
+            standard_treasury: Address::repeat_byte(0x05),
+            core_members_group_deployer: Address::repeat_byte(0x06),
+            base_group_factory_address: Address::repeat_byte(0x07),
+            lift_erc20_address: Address::repeat_byte(0x08),
+            invitation_escrow_address: Address::repeat_byte(0x09),
+            invitation_farm_address: Address::repeat_byte(0x0a),
+            referrals_module_address: Address::repeat_byte(0x0b),
+        }
+    }
+
+    fn dummy_avatar(address: Address) -> AvatarInfo {
+        AvatarInfo {
+            block_number: 0,
+            timestamp: None,
+            transaction_index: 0,
+            log_index: 0,
+            transaction_hash: TxHash::ZERO,
+            version: 2,
+            avatar_type: AvatarType::CrcV2RegisterGroup,
+            avatar: address,
+            token_id: None,
+            has_v1: false,
+            v1_token: None,
+            cid_v0_digest: None,
+            cid_v0: None,
+            v1_stopped: None,
+            is_human: false,
+            name: None,
+            symbol: None,
+        }
+    }
+
+    fn test_avatar() -> (BaseGroupAvatar, Arc<RecordingRunner>) {
+        let config = dummy_config();
+        let runner = Arc::new(RecordingRunner {
+            sender: Address::repeat_byte(0xcc),
+            sent: Mutex::new(Vec::new()),
+        });
+        let avatar = BaseGroupAvatar::new(
+            Address::repeat_byte(0xcc),
+            dummy_avatar(Address::repeat_byte(0xcc)),
+            Arc::new(Core::new(config.clone())),
+            Profiles::new(config.profile_service_url.clone()).expect("profiles"),
+            Arc::new(CirclesRpc::try_from_http(&config.circles_rpc_url).expect("rpc")),
+            Some(runner.clone()),
+        );
+        (avatar, runner)
+    }
+
+    #[tokio::test]
+    async fn base_group_write_helpers_encode_expected_calls() {
+        let (avatar, runner) = test_avatar();
+        let new_owner = Address::repeat_byte(0xdd);
+        let new_service = Address::repeat_byte(0xee);
+        let new_fee = Address::repeat_byte(0xff);
+        let condition = Address::repeat_byte(0x11);
+
+        avatar
+            .update_profile_metadata(TEST_CID)
+            .await
+            .expect("update metadata");
+        avatar
+            .register_short_name(5)
+            .await
+            .expect("register short name");
+        avatar
+            .trust_add_batch_with_conditions(&[new_owner, new_service], 42)
+            .await
+            .expect("trust batch");
+        avatar.set_owner(new_owner).await.expect("set owner");
+        avatar.set_service(new_service).await.expect("set service");
+        avatar
+            .set_fee_collection(new_fee)
+            .await
+            .expect("set fee collection");
+        avatar
+            .set_membership_condition(condition, true)
+            .await
+            .expect("set membership condition");
+
+        let sent = runner.sent.lock().expect("lock");
+        assert_eq!(sent.len(), 7);
+
+        assert_eq!(
+            &sent[0][0].data[..4],
+            &BaseGroup::updateMetadataDigestCall {
+                _metadataDigest: cid_v0_to_digest(TEST_CID).expect("cid"),
+            }
+            .abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[1][0].data[..4],
+            &BaseGroup::registerShortNameWithNonceCall {
+                _nonce: U256::from(5u64),
+            }
+            .abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[2][0].data[..4],
+            &BaseGroup::trustBatchWithConditionsCall {
+                _members: vec![new_owner, new_service],
+                _expiry: U96::from(42u128),
+            }
+            .abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[3][0].data[..4],
+            &BaseGroup::setOwnerCall { _owner: new_owner }.abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[4][0].data[..4],
+            &BaseGroup::setServiceCall {
+                _service: new_service,
+            }
+            .abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[5][0].data[..4],
+            &BaseGroup::setFeeCollectionCall {
+                _feeCollection: new_fee,
+            }
+            .abi_encode()[..4]
+        );
+        assert_eq!(
+            &sent[6][0].data[..4],
+            &BaseGroup::setMembershipConditionCall {
+                _condition: condition,
+                _enabled: true,
+            }
+            .abi_encode()[..4]
+        );
     }
 }

--- a/crates/sdk/src/avatar/base_group.rs
+++ b/crates/sdk/src/avatar/base_group.rs
@@ -50,6 +50,23 @@ impl BaseGroupAvatar {
         self.common.total_balance(as_time_circles, use_v2).await
     }
 
+    /// Get the total supply of this group's token.
+    pub async fn total_supply(&self) -> Result<U256, SdkError> {
+        let token_id = self
+            .core
+            .hub_v2()
+            .toTokenId(self.address)
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        self.core
+            .hub_v2()
+            .totalSupply(token_id)
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
     /// Get trust relations.
     pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
         self.common.trust_relations().await
@@ -85,6 +102,56 @@ impl BaseGroupAvatar {
     /// Check whether `other_avatar` trusts this avatar.
     pub async fn is_trusted_by(&self, other_avatar: Address) -> Result<bool, SdkError> {
         self.common.is_trusted_by(other_avatar).await
+    }
+
+    /// Get the group owner address.
+    pub async fn owner(&self) -> Result<Address, SdkError> {
+        self.core
+            .base_group(self.address)
+            .owner()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the mint handler address.
+    pub async fn mint_handler(&self) -> Result<Address, SdkError> {
+        self.core
+            .base_group(self.address)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the service address.
+    pub async fn service(&self) -> Result<Address, SdkError> {
+        self.core
+            .base_group(self.address)
+            .service()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the fee collection address.
+    pub async fn fee_collection(&self) -> Result<Address, SdkError> {
+        self.core
+            .base_group(self.address)
+            .feeCollection()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get all membership conditions.
+    pub async fn membership_conditions(&self) -> Result<Vec<Address>, SdkError> {
+        self.core
+            .base_group(self.address)
+            .getMembershipConditions()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
     }
 
     /// Fetch profile (cached by CID in memory).

--- a/crates/sdk/src/avatar/common.rs
+++ b/crates/sdk/src/avatar/common.rs
@@ -8,7 +8,8 @@ use circles_rpc::CirclesRpc;
 use circles_rpc::events::subscription::CirclesSubscription;
 use circles_transfers::TransferBuilder;
 use circles_types::{
-    AdvancedTransferOptions, PathfindingResult, TokenBalanceResponse, TrustRelation,
+    AdvancedTransferOptions, AggregatedTrustRelation, Balance, PathfindingResult,
+    TokenBalanceResponse, TrustRelation, TrustRelationType,
 };
 #[cfg(feature = "ws")]
 use circles_types::{CirclesEvent, Filter};
@@ -58,9 +59,78 @@ impl CommonAvatar {
             .await?)
     }
 
+    /// Get aggregate balance (v1/v2 selectable).
+    pub async fn total_balance(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Balance, SdkError> {
+        Ok(self
+            .rpc
+            .balance()
+            .get_total_balance(self.address, as_time_circles, use_v2)
+            .await?)
+    }
+
     /// Get trust relations.
     pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
         Ok(self.rpc.trust().get_trust_relations(self.address).await?)
+    }
+
+    /// Get aggregated trust relations, matching the TS SDK convenience surface.
+    pub async fn aggregated_trust_relations(
+        &self,
+    ) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        Ok(self
+            .rpc
+            .trust()
+            .get_aggregated_trust_relations(self.address)
+            .await?)
+    }
+
+    /// Get outgoing trust relations only.
+    pub async fn trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        Ok(self.rpc.trust().get_trusts(self.address).await?)
+    }
+
+    /// Get incoming trust relations only.
+    pub async fn trusted_by(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        Ok(self.rpc.trust().get_trusted_by(self.address).await?)
+    }
+
+    /// Get mutual trust relations only.
+    pub async fn mutual_trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        Ok(self.rpc.trust().get_mutual_trusts(self.address).await?)
+    }
+
+    /// Check whether this avatar trusts `other_avatar`.
+    pub async fn is_trusting(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        let rels = self
+            .rpc
+            .trust()
+            .get_common_trust(self.address, other_avatar)
+            .await?;
+        Ok(rels.iter().any(|rel| {
+            matches!(
+                rel,
+                TrustRelationType::Trusts | TrustRelationType::MutuallyTrusts
+            )
+        }))
+    }
+
+    /// Check whether `other_avatar` trusts this avatar.
+    pub async fn is_trusted_by(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        let rels = self
+            .rpc
+            .trust()
+            .get_common_trust(self.address, other_avatar)
+            .await?;
+        Ok(rels.iter().any(|rel| {
+            matches!(
+                rel,
+                TrustRelationType::TrustedBy | TrustRelationType::MutuallyTrusts
+            )
+        }))
     }
 
     /// Fetch profile by CID if present.

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -297,6 +297,75 @@ impl HumanAvatar {
         self.common.send(txs).await
     }
 
+    /// Plan a group-token mint by routing collateral to the group's mint handler.
+    pub async fn plan_group_token_mint(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let mint_handler = self
+            .core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        self.plan_transfer(
+            mint_handler,
+            amount,
+            Some(AdvancedTransferOptions {
+                use_wrapped_balances: Some(true),
+                from_tokens: None,
+                to_tokens: None,
+                exclude_from_tokens: None,
+                exclude_to_tokens: None,
+                simulated_balances: None,
+                simulated_trusts: None,
+                max_transfers: None,
+                tx_data: None,
+            }),
+        )
+        .await
+    }
+
+    /// Execute a group-token mint by routing collateral to the group's mint handler.
+    pub async fn mint_group_token(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let txs = self.plan_group_token_mint(group, amount).await?;
+        self.common.send(txs).await
+    }
+
+    /// Compute the maximum amount mintable for a group from this avatar.
+    pub async fn max_group_token_mintable(&self, group: Address) -> Result<U256, SdkError> {
+        let mint_handler = self
+            .core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        Ok(self
+            .max_flow_to(
+                mint_handler,
+                Some(AdvancedTransferOptions {
+                    use_wrapped_balances: Some(true),
+                    from_tokens: None,
+                    to_tokens: None,
+                    exclude_from_tokens: None,
+                    exclude_to_tokens: None,
+                    simulated_balances: None,
+                    simulated_trusts: None,
+                    max_transfers: None,
+                    tx_data: None,
+                }),
+            )
+            .await?
+            .max_flow)
+    }
+
     /// Find a path from this avatar to `to` for the requested target flow.
     pub async fn find_path(
         &self,
@@ -314,6 +383,69 @@ impl HumanAvatar {
         options: Option<AdvancedTransferOptions>,
     ) -> Result<PathfindingResult, SdkError> {
         self.common.max_flow_to(to, options).await
+    }
+
+    /// Get the owner address for a group.
+    pub async fn group_owner(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .owner()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the mint handler address for a group.
+    pub async fn group_mint_handler(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the treasury address for a group.
+    pub async fn group_treasury(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .BASE_TREASURY()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the service address for a group.
+    pub async fn group_service(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .service()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the fee collection address for a group.
+    pub async fn group_fee_collection(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .feeCollection()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get all membership conditions for a group.
+    pub async fn group_membership_conditions(
+        &self,
+        group: Address,
+    ) -> Result<Vec<Address>, SdkError> {
+        self.core
+            .base_group(group)
+            .getMembershipConditions()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
     }
 
     /// Mint all currently claimable personal tokens (requires runner).

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -14,7 +14,8 @@ use circles_rpc::events::subscription::CirclesSubscription;
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
-    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+    AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
+    TokenBalanceResponse, TrustRelation,
 };
 use hex::encode as hex_encode;
 use rand::RngCore;
@@ -64,9 +65,50 @@ impl HumanAvatar {
         self.common.balances(as_time_circles, use_v2).await
     }
 
+    /// Get aggregate balance (v1/v2 selectable).
+    pub async fn total_balance(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Balance, SdkError> {
+        self.common.total_balance(as_time_circles, use_v2).await
+    }
+
     /// Get trust relations.
     pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
         self.common.trust_relations().await
+    }
+
+    /// Get aggregated trust relations.
+    pub async fn aggregated_trust_relations(
+        &self,
+    ) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.aggregated_trust_relations().await
+    }
+
+    /// Get outgoing trust relations only.
+    pub async fn trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusts().await
+    }
+
+    /// Get incoming trust relations only.
+    pub async fn trusted_by(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusted_by().await
+    }
+
+    /// Get mutual trust relations only.
+    pub async fn mutual_trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.mutual_trusts().await
+    }
+
+    /// Check whether this avatar trusts `other_avatar`.
+    pub async fn is_trusting(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusting(other_avatar).await
+    }
+
+    /// Check whether `other_avatar` trusts this avatar.
+    pub async fn is_trusted_by(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusted_by(other_avatar).await
     }
 
     /// Fetch profile (cached by CID in memory).
@@ -77,13 +119,26 @@ impl HumanAvatar {
     /// Update profile via profiles service and store CID through NameRegistry (requires runner).
     pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
         let cid = self.common.pin_profile(profile).await?;
-        let digest = cid_v0_to_digest(&cid)?;
+        self.update_profile_metadata(&cid).await
+    }
+
+    /// Update the on-chain profile CID pointer through NameRegistry (requires runner).
+    pub async fn update_profile_metadata(&self, cid: &str) -> Result<Vec<SubmittedTx>, SdkError> {
+        let digest = cid_v0_to_digest(cid)?;
         let call = circles_abis::NameRegistry::updateMetadataDigestCall {
             _metadataDigest: digest,
         };
         let tx = call_to_tx(self.core.config.name_registry_address, call, None);
-        let sent = self.common.send(vec![tx]).await?;
-        Ok(sent)
+        self.common.send(vec![tx]).await
+    }
+
+    /// Register a short name using a specific nonce (requires runner).
+    pub async fn register_short_name(&self, nonce: u64) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = circles_abis::NameRegistry::registerShortNameWithNonceCall {
+            _nonce: U256::from(nonce),
+        };
+        let tx = call_to_tx(self.core.config.name_registry_address, call, None);
+        self.common.send(vec![tx]).await
     }
 
     /// Trust one or more avatars via HubV2::trust (requires runner).
@@ -190,6 +245,58 @@ impl HumanAvatar {
         self.common.replenish(token_id, amount, receiver).await
     }
 
+    /// Compute the maximum amount that can be replenished into this human's own token.
+    pub async fn max_replenishable(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<U256, SdkError> {
+        let mut opts = options.unwrap_or(AdvancedTransferOptions {
+            use_wrapped_balances: None,
+            from_tokens: None,
+            to_tokens: None,
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            simulated_trusts: None,
+            max_transfers: None,
+            tx_data: None,
+        });
+        if opts.use_wrapped_balances.is_none() {
+            opts.use_wrapped_balances = Some(true);
+        }
+        if opts.to_tokens.is_none() {
+            opts.to_tokens = Some(vec![self.address]);
+        }
+        Ok(self
+            .common
+            .find_path(self.address, U256::MAX, Some(opts))
+            .await?
+            .max_flow)
+    }
+
+    /// Plan a replenish flow for the maximum currently replenishable amount.
+    pub async fn plan_replenish_max(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let max_amount = self.max_replenishable(options).await?;
+        if max_amount.is_zero() {
+            return Err(SdkError::OperationFailed(
+                "no tokens available to replenish".to_string(),
+            ));
+        }
+        self.plan_replenish(self.address, max_amount, None).await
+    }
+
+    /// Execute a replenish flow for the maximum currently replenishable amount.
+    pub async fn replenish_max(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let txs = self.plan_replenish_max(options).await?;
+        self.common.send(txs).await
+    }
+
     /// Find a path from this avatar to `to` for the requested target flow.
     pub async fn find_path(
         &self,
@@ -207,6 +314,20 @@ impl HumanAvatar {
         options: Option<AdvancedTransferOptions>,
     ) -> Result<PathfindingResult, SdkError> {
         self.common.max_flow_to(to, options).await
+    }
+
+    /// Mint all currently claimable personal tokens (requires runner).
+    pub async fn personal_mint(&self) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = HubV2::personalMintCall {};
+        let tx = call_to_tx(self.core.config.v2_hub_address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Permanently stop personal token minting (requires runner).
+    pub async fn stop_mint(&self) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = HubV2::stopCall {};
+        let tx = call_to_tx(self.core.config.v2_hub_address, call, None);
+        self.common.send(vec![tx]).await
     }
 
     /// Generate invitation secrets/signers and return prepared transactions (claim + batch transfer).
@@ -377,7 +498,97 @@ impl HumanAvatar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Bytes, address};
+    use alloy_primitives::{Bytes, TxHash, address};
+    use async_trait::async_trait;
+    use circles_profiles::Profiles;
+    use circles_types::{AvatarType, CirclesConfig};
+    use std::sync::Mutex;
+
+    const TEST_CID: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        sender: Address,
+        sent: Mutex<Vec<Vec<PreparedTransaction>>>,
+    }
+
+    #[async_trait]
+    impl ContractRunner for RecordingRunner {
+        fn sender_address(&self) -> Address {
+            self.sender
+        }
+
+        async fn send_transactions(
+            &self,
+            txs: Vec<PreparedTransaction>,
+        ) -> Result<Vec<crate::SubmittedTx>, crate::RunnerError> {
+            self.sent.lock().expect("lock").push(txs.clone());
+            Ok(txs
+                .into_iter()
+                .map(|_| crate::SubmittedTx {
+                    tx_hash: Bytes::from(TxHash::ZERO.as_slice().to_vec()),
+                })
+                .collect())
+        }
+    }
+
+    fn dummy_config() -> CirclesConfig {
+        CirclesConfig {
+            circles_rpc_url: "https://rpc.example.com".into(),
+            pathfinder_url: "https://pathfinder.example.com".into(),
+            profile_service_url: "https://profiles.example.com".into(),
+            v1_hub_address: Address::repeat_byte(0x01),
+            v2_hub_address: Address::repeat_byte(0x02),
+            name_registry_address: Address::repeat_byte(0x03),
+            base_group_mint_policy: Address::repeat_byte(0x04),
+            standard_treasury: Address::repeat_byte(0x05),
+            core_members_group_deployer: Address::repeat_byte(0x06),
+            base_group_factory_address: Address::repeat_byte(0x07),
+            lift_erc20_address: Address::repeat_byte(0x08),
+            invitation_escrow_address: Address::repeat_byte(0x09),
+            invitation_farm_address: Address::repeat_byte(0x0a),
+            referrals_module_address: Address::repeat_byte(0x0b),
+        }
+    }
+
+    fn dummy_avatar(address: Address) -> AvatarInfo {
+        AvatarInfo {
+            block_number: 0,
+            timestamp: None,
+            transaction_index: 0,
+            log_index: 0,
+            transaction_hash: TxHash::ZERO,
+            version: 2,
+            avatar_type: AvatarType::CrcV2RegisterHuman,
+            avatar: address,
+            token_id: None,
+            has_v1: false,
+            v1_token: None,
+            cid_v0_digest: None,
+            cid_v0: None,
+            v1_stopped: None,
+            is_human: true,
+            name: None,
+            symbol: None,
+        }
+    }
+
+    fn test_avatar() -> (HumanAvatar, Arc<RecordingRunner>, CirclesConfig) {
+        let config = dummy_config();
+        let runner = Arc::new(RecordingRunner {
+            sender: Address::repeat_byte(0xaa),
+            sent: Mutex::new(Vec::new()),
+        });
+        let avatar = HumanAvatar::new(
+            Address::repeat_byte(0xaa),
+            dummy_avatar(Address::repeat_byte(0xaa)),
+            Arc::new(Core::new(config.clone())),
+            Profiles::new(config.profile_service_url.clone()).expect("profiles"),
+            Arc::new(CirclesRpc::try_from_http(&config.circles_rpc_url).expect("rpc")),
+            Some(runner.clone()),
+        );
+        (avatar, runner, config)
+    }
 
     #[test]
     fn referral_payload_encodes() {
@@ -414,5 +625,51 @@ mod tests {
             batch_tx.to,
             address!("cccc000000000000000000000000000000000000")
         );
+    }
+
+    #[tokio::test]
+    async fn write_helpers_encode_expected_calls() {
+        let (avatar, runner, config) = test_avatar();
+
+        avatar
+            .update_profile_metadata(TEST_CID)
+            .await
+            .expect("update metadata");
+        avatar
+            .register_short_name(7)
+            .await
+            .expect("register short name");
+        avatar.personal_mint().await.expect("personal mint");
+        avatar.stop_mint().await.expect("stop mint");
+
+        let sent = runner.sent.lock().expect("lock");
+        assert_eq!(sent.len(), 4);
+
+        assert_eq!(sent[0][0].to, config.name_registry_address);
+        assert_eq!(
+            &sent[0][0].data[..4],
+            &circles_abis::NameRegistry::updateMetadataDigestCall {
+                _metadataDigest: cid_v0_to_digest(TEST_CID).expect("cid"),
+            }
+            .abi_encode()[..4]
+        );
+
+        assert_eq!(sent[1][0].to, config.name_registry_address);
+        assert_eq!(
+            &sent[1][0].data[..4],
+            &circles_abis::NameRegistry::registerShortNameWithNonceCall {
+                _nonce: U256::from(7u64),
+            }
+            .abi_encode()[..4]
+        );
+
+        assert_eq!(sent[2][0].to, config.v2_hub_address);
+        assert_eq!(
+            &sent[2][0].data[..4],
+            &HubV2::personalMintCall {}.abi_encode()[..4]
+        );
+
+        assert_eq!(sent[3][0].to, config.v2_hub_address);
+        assert_eq!(&sent[3][0].data[..4], &HubV2::stopCall {}.abi_encode()[..4]);
     }
 }

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -12,7 +12,8 @@ use circles_rpc::events::subscription::CirclesSubscription;
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
-    AdvancedTransferOptions, AvatarInfo, PathfindingResult, TokenBalanceResponse, TrustRelation,
+    AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
+    TokenBalanceResponse, TrustRelation,
 };
 use std::sync::Arc;
 
@@ -40,9 +41,50 @@ impl OrganisationAvatar {
         self.common.balances(as_time_circles, use_v2).await
     }
 
+    /// Get aggregate balance (v1/v2 selectable).
+    pub async fn total_balance(
+        &self,
+        as_time_circles: bool,
+        use_v2: bool,
+    ) -> Result<Balance, SdkError> {
+        self.common.total_balance(as_time_circles, use_v2).await
+    }
+
     /// Get trust relations.
     pub async fn trust_relations(&self) -> Result<Vec<TrustRelation>, SdkError> {
         self.common.trust_relations().await
+    }
+
+    /// Get aggregated trust relations.
+    pub async fn aggregated_trust_relations(
+        &self,
+    ) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.aggregated_trust_relations().await
+    }
+
+    /// Get outgoing trust relations only.
+    pub async fn trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusts().await
+    }
+
+    /// Get incoming trust relations only.
+    pub async fn trusted_by(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.trusted_by().await
+    }
+
+    /// Get mutual trust relations only.
+    pub async fn mutual_trusts(&self) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        self.common.mutual_trusts().await
+    }
+
+    /// Check whether this avatar trusts `other_avatar`.
+    pub async fn is_trusting(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusting(other_avatar).await
+    }
+
+    /// Check whether `other_avatar` trusts this avatar.
+    pub async fn is_trusted_by(&self, other_avatar: Address) -> Result<bool, SdkError> {
+        self.common.is_trusted_by(other_avatar).await
     }
 
     /// Fetch profile (cached by CID in memory).
@@ -53,9 +95,23 @@ impl OrganisationAvatar {
     /// Update profile via profiles service and store CID through NameRegistry (requires runner).
     pub async fn update_profile(&self, profile: &Profile) -> Result<Vec<SubmittedTx>, SdkError> {
         let cid = self.common.pin_profile(profile).await?;
-        let digest = cid_v0_to_digest(&cid)?;
+        self.update_profile_metadata(&cid).await
+    }
+
+    /// Update the on-chain profile CID pointer through NameRegistry (requires runner).
+    pub async fn update_profile_metadata(&self, cid: &str) -> Result<Vec<SubmittedTx>, SdkError> {
+        let digest = cid_v0_to_digest(cid)?;
         let call = circles_abis::NameRegistry::updateMetadataDigestCall {
             _metadataDigest: digest,
+        };
+        let tx = call_to_tx(self.core.config.name_registry_address, call, None);
+        self.common.send(vec![tx]).await
+    }
+
+    /// Register a short name using a specific nonce (requires runner).
+    pub async fn register_short_name(&self, nonce: u64) -> Result<Vec<SubmittedTx>, SdkError> {
+        let call = circles_abis::NameRegistry::registerShortNameWithNonceCall {
+            _nonce: U256::from(nonce),
         };
         let tx = call_to_tx(self.core.config.name_registry_address, call, None);
         self.common.send(vec![tx]).await
@@ -133,6 +189,58 @@ impl OrganisationAvatar {
         self.common.replenish(token_id, amount, receiver).await
     }
 
+    /// Compute the maximum amount that can be replenished into this organisation's own token.
+    pub async fn max_replenishable(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<U256, SdkError> {
+        let mut opts = options.unwrap_or(AdvancedTransferOptions {
+            use_wrapped_balances: None,
+            from_tokens: None,
+            to_tokens: None,
+            exclude_from_tokens: None,
+            exclude_to_tokens: None,
+            simulated_balances: None,
+            simulated_trusts: None,
+            max_transfers: None,
+            tx_data: None,
+        });
+        if opts.use_wrapped_balances.is_none() {
+            opts.use_wrapped_balances = Some(true);
+        }
+        if opts.to_tokens.is_none() {
+            opts.to_tokens = Some(vec![self.address]);
+        }
+        Ok(self
+            .common
+            .find_path(self.address, U256::MAX, Some(opts))
+            .await?
+            .max_flow)
+    }
+
+    /// Plan a replenish flow for the maximum currently replenishable amount.
+    pub async fn plan_replenish_max(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let max_amount = self.max_replenishable(options).await?;
+        if max_amount.is_zero() {
+            return Err(SdkError::OperationFailed(
+                "no tokens available to replenish".to_string(),
+            ));
+        }
+        self.plan_replenish(self.address, max_amount, None).await
+    }
+
+    /// Execute a replenish flow for the maximum currently replenishable amount.
+    pub async fn replenish_max(
+        &self,
+        options: Option<AdvancedTransferOptions>,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let txs = self.plan_replenish_max(options).await?;
+        self.common.send(txs).await
+    }
+
     /// Find a path between this avatar and `to` with a target flow.
     pub async fn find_path(
         &self,
@@ -169,5 +277,137 @@ impl OrganisationAvatar {
             runner,
             common,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, TxHash};
+    use alloy_sol_types::SolCall;
+    use async_trait::async_trait;
+    use circles_profiles::Profiles;
+    use circles_types::{AvatarType, CirclesConfig};
+    use std::sync::Mutex;
+
+    const TEST_CID: &str = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+
+    #[derive(Default)]
+    struct RecordingRunner {
+        sender: Address,
+        sent: Mutex<Vec<Vec<PreparedTransaction>>>,
+    }
+
+    #[async_trait]
+    impl ContractRunner for RecordingRunner {
+        fn sender_address(&self) -> Address {
+            self.sender
+        }
+
+        async fn send_transactions(
+            &self,
+            txs: Vec<PreparedTransaction>,
+        ) -> Result<Vec<crate::SubmittedTx>, crate::RunnerError> {
+            self.sent.lock().expect("lock").push(txs.clone());
+            Ok(txs
+                .into_iter()
+                .map(|_| crate::SubmittedTx {
+                    tx_hash: Bytes::from(TxHash::ZERO.as_slice().to_vec()),
+                })
+                .collect())
+        }
+    }
+
+    fn dummy_config() -> CirclesConfig {
+        CirclesConfig {
+            circles_rpc_url: "https://rpc.example.com".into(),
+            pathfinder_url: "https://pathfinder.example.com".into(),
+            profile_service_url: "https://profiles.example.com".into(),
+            v1_hub_address: Address::repeat_byte(0x01),
+            v2_hub_address: Address::repeat_byte(0x02),
+            name_registry_address: Address::repeat_byte(0x03),
+            base_group_mint_policy: Address::repeat_byte(0x04),
+            standard_treasury: Address::repeat_byte(0x05),
+            core_members_group_deployer: Address::repeat_byte(0x06),
+            base_group_factory_address: Address::repeat_byte(0x07),
+            lift_erc20_address: Address::repeat_byte(0x08),
+            invitation_escrow_address: Address::repeat_byte(0x09),
+            invitation_farm_address: Address::repeat_byte(0x0a),
+            referrals_module_address: Address::repeat_byte(0x0b),
+        }
+    }
+
+    fn dummy_avatar(address: Address) -> AvatarInfo {
+        AvatarInfo {
+            block_number: 0,
+            timestamp: None,
+            transaction_index: 0,
+            log_index: 0,
+            transaction_hash: TxHash::ZERO,
+            version: 2,
+            avatar_type: AvatarType::CrcV2RegisterOrganization,
+            avatar: address,
+            token_id: None,
+            has_v1: false,
+            v1_token: None,
+            cid_v0_digest: None,
+            cid_v0: None,
+            v1_stopped: None,
+            is_human: false,
+            name: None,
+            symbol: None,
+        }
+    }
+
+    fn test_avatar() -> (OrganisationAvatar, Arc<RecordingRunner>, CirclesConfig) {
+        let config = dummy_config();
+        let runner = Arc::new(RecordingRunner {
+            sender: Address::repeat_byte(0xbb),
+            sent: Mutex::new(Vec::new()),
+        });
+        let avatar = OrganisationAvatar::new(
+            Address::repeat_byte(0xbb),
+            dummy_avatar(Address::repeat_byte(0xbb)),
+            Arc::new(Core::new(config.clone())),
+            Profiles::new(config.profile_service_url.clone()).expect("profiles"),
+            Arc::new(CirclesRpc::try_from_http(&config.circles_rpc_url).expect("rpc")),
+            Some(runner.clone()),
+        );
+        (avatar, runner, config)
+    }
+
+    #[tokio::test]
+    async fn profile_write_helpers_encode_expected_calls() {
+        let (avatar, runner, config) = test_avatar();
+
+        avatar
+            .update_profile_metadata(TEST_CID)
+            .await
+            .expect("update metadata");
+        avatar
+            .register_short_name(9)
+            .await
+            .expect("register short name");
+
+        let sent = runner.sent.lock().expect("lock");
+        assert_eq!(sent.len(), 2);
+
+        assert_eq!(sent[0][0].to, config.name_registry_address);
+        assert_eq!(
+            &sent[0][0].data[..4],
+            &circles_abis::NameRegistry::updateMetadataDigestCall {
+                _metadataDigest: cid_v0_to_digest(TEST_CID).expect("cid"),
+            }
+            .abi_encode()[..4]
+        );
+
+        assert_eq!(sent[1][0].to, config.name_registry_address);
+        assert_eq!(
+            &sent[1][0].data[..4],
+            &circles_abis::NameRegistry::registerShortNameWithNonceCall {
+                _nonce: U256::from(9u64),
+            }
+            .abi_encode()[..4]
+        );
     }
 }

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -241,6 +241,75 @@ impl OrganisationAvatar {
         self.common.send(txs).await
     }
 
+    /// Plan a group-token mint by routing collateral to the group's mint handler.
+    pub async fn plan_group_token_mint(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let mint_handler = self
+            .core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        self.plan_transfer(
+            mint_handler,
+            amount,
+            Some(AdvancedTransferOptions {
+                use_wrapped_balances: Some(true),
+                from_tokens: None,
+                to_tokens: None,
+                exclude_from_tokens: None,
+                exclude_to_tokens: None,
+                simulated_balances: None,
+                simulated_trusts: None,
+                max_transfers: None,
+                tx_data: None,
+            }),
+        )
+        .await
+    }
+
+    /// Execute a group-token mint by routing collateral to the group's mint handler.
+    pub async fn mint_group_token(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        let txs = self.plan_group_token_mint(group, amount).await?;
+        self.common.send(txs).await
+    }
+
+    /// Compute the maximum amount mintable for a group from this avatar.
+    pub async fn max_group_token_mintable(&self, group: Address) -> Result<U256, SdkError> {
+        let mint_handler = self
+            .core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        Ok(self
+            .max_flow_to(
+                mint_handler,
+                Some(AdvancedTransferOptions {
+                    use_wrapped_balances: Some(true),
+                    from_tokens: None,
+                    to_tokens: None,
+                    exclude_from_tokens: None,
+                    exclude_to_tokens: None,
+                    simulated_balances: None,
+                    simulated_trusts: None,
+                    max_transfers: None,
+                    tx_data: None,
+                }),
+            )
+            .await?
+            .max_flow)
+    }
+
     /// Find a path between this avatar and `to` with a target flow.
     pub async fn find_path(
         &self,
@@ -258,6 +327,69 @@ impl OrganisationAvatar {
         options: Option<AdvancedTransferOptions>,
     ) -> Result<PathfindingResult, SdkError> {
         self.common.max_flow_to(to, options).await
+    }
+
+    /// Get the owner address for a group.
+    pub async fn group_owner(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .owner()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the mint handler address for a group.
+    pub async fn group_mint_handler(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .BASE_MINT_HANDLER()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the treasury address for a group.
+    pub async fn group_treasury(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .BASE_TREASURY()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the service address for a group.
+    pub async fn group_service(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .service()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get the fee collection address for a group.
+    pub async fn group_fee_collection(&self, group: Address) -> Result<Address, SdkError> {
+        self.core
+            .base_group(group)
+            .feeCollection()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get all membership conditions for a group.
+    pub async fn group_membership_conditions(
+        &self,
+        group: Address,
+    ) -> Result<Vec<Address>, SdkError> {
+        self.core
+            .base_group(group)
+            .getMembershipConditions()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))
     }
 
     /// Build a typed organisation avatar wrapper from already-fetched components.

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -72,7 +72,10 @@ use circles_rpc::CirclesRpc;
 use circles_rpc::events::subscription::CirclesSubscription;
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
-use circles_types::{AvatarInfo, AvatarType, CirclesConfig, TokenBalanceResponse, TrustRelation};
+use circles_types::{
+    AggregatedTrustRelation, AvatarInfo, AvatarType, CirclesConfig, TokenBalanceResponse,
+    TrustRelation,
+};
 use core::Core;
 pub use runner::{ContractRunner, PreparedTransaction, RunnerError, SubmittedTx, call_to_tx};
 #[cfg(feature = "ws")]
@@ -103,6 +106,10 @@ pub enum SdkError {
     Runner(#[from] RunnerError),
     #[error("cid error: {0}")]
     Cid(#[from] cid_v0_to_digest::CidError),
+    #[error("contract call error: {0}")]
+    Contract(String),
+    #[error("operation failed: {0}")]
+    OperationFailed(String),
     #[error("contract runner is required for this operation")]
     MissingRunner,
     #[error("sender address is required for this operation")]
@@ -197,6 +204,18 @@ impl Sdk {
     /// Read trust relations for an avatar directly from the RPC service.
     pub async fn data_trust(&self, avatar: Address) -> Result<Vec<TrustRelation>, SdkError> {
         Ok(self.rpc.trust().get_trust_relations(avatar).await?)
+    }
+
+    /// Read aggregated trust relations for an avatar directly from the RPC service.
+    pub async fn data_trust_aggregated(
+        &self,
+        avatar: Address,
+    ) -> Result<Vec<AggregatedTrustRelation>, SdkError> {
+        Ok(self
+            .rpc
+            .trust()
+            .get_aggregated_trust_relations(avatar)
+            .await?)
     }
 
     /// Read token balances for an avatar directly from the RPC service.


### PR DESCRIPTION
## Summary
- add aggregated trust parity helpers to circles-rpc and circles-sdk
- add SDK convenience helpers for profile metadata, short names, personal minting, replenish max flows, base-group reads/writes, and group-token mint/property flows
- update the parity snapshot and SDK docs to record the remaining convenience gaps

## Validation
- cargo check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test