### PR TITLE
feat: add rpc history and group membership parity helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,6 +1134,7 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ws",
  "circles-types",
+ "circles-utils",
  "futures",
  "reqwest",
  "serde",

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ As of March 26, 2026, this workspace is closer to the TypeScript SDK, but it is 
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place and is already used by the higher-level crates. |
+| `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place, including paged transaction history plus group-membership/group-query helpers used by the higher-level crates. |
 | `circles-pathfinder` | Close | Recent parity work aligned flow-matrix terminal edges, wrapped-token rewriting, token-info helpers, netted-flow helpers, and explicit RPC/client entrypoints. |
 | `circles-transfers` | Close | Advanced transfer planning, aggregate transfers, and the TS-style `constructReplenish` flow are present; remaining work is mostly higher-level parity polish and broader behavioral coverage. |
-| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, profile metadata / short-name writes, personal minting, max-replenish helpers, base-group read/write helpers, and group-token mint/property helpers; direct-transfer/history/full group-token parity and wallet-backend parity are still incomplete. |
+| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, transaction-history pagination, profile metadata / short-name writes, personal minting, max-replenish helpers, base-group read/write helpers, human group-membership detail helpers, and group-token mint/property helpers; direct-transfer, fuller group-token parity, and wallet-backend parity are still incomplete. |
 | `circles-profiles`, `circles-utils`, `circles-types`, `circles-abis` | Supporting / lower risk | These crates are in service for the current SDK flows and are not the main parity bottlenecks right now. |
 
-The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially TS-style direct transfer/history helpers, full group-token redeem/group-membership parity, and wallet-specific flows outside the generic runner abstraction.
+The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially TS-style direct transfer helpers, fuller group-token redeem/member convenience, the richer invitation surface, and wallet-specific flows outside the generic runner abstraction.
 
 ## Usage model
 

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -15,6 +15,7 @@ alloy-provider = { workspace = true }
 alloy-transport-http = { workspace = true }
 alloy-transport-ws = { workspace = true, optional = true }
 circles-types = { workspace = true }
+circles-utils = { workspace = true }
 futures = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -20,7 +20,7 @@ pub use events::EventStream;
 pub use methods::{
     AvatarMethods, BalanceMethods, EventsMethods, GroupMethods, HealthMethods, InvitationMethods,
     NetworkMethods, PathfinderMethods, QueryMethods, SearchMethods, TablesMethods,
-    TokenInfoMethods, TokenMethods, TrustMethods,
+    TokenInfoMethods, TokenMethods, TransactionMethods, TrustMethods,
 };
 pub use paged_query::{Page, PagedQuery};
 pub use rpc::CirclesRpc;

--- a/crates/rpc/src/methods/group.rs
+++ b/crates/rpc/src/methods/group.rs
@@ -1,6 +1,13 @@
 use crate::client::RpcClient;
 use crate::error::Result;
-use circles_types::{GroupMembershipRow, GroupRow};
+use crate::methods::QueryMethods;
+use crate::paged_query::{PagedFetch, PagedQuery};
+use circles_types::{
+    Address, Conjunction, Filter, FilterPredicate, GroupMembershipRow, GroupQueryParams, GroupRow,
+    PagedQueryParams, SortOrder,
+};
+use std::pin::Pin;
+use std::sync::Arc;
 
 /// Methods for group membership lookups (`circles_getGroupMemberships`, `circles_getGroups`).
 #[derive(Clone, Debug)]
@@ -14,18 +21,276 @@ impl GroupMethods {
         Self { client }
     }
 
+    fn paged_query<TRow>(&self, params: PagedQueryParams) -> PagedQuery<TRow>
+    where
+        TRow: serde::de::DeserializeOwned
+            + serde::Serialize
+            + Clone
+            + Send
+            + Sync
+            + std::fmt::Debug
+            + Unpin
+            + 'static,
+    {
+        let client = self.client.clone();
+        let fetch: PagedFetch<TRow> = Arc::new(move |params: PagedQueryParams| {
+            let client = client.clone();
+            Box::pin(async move { QueryMethods::new(client).paged_query::<TRow>(params).await })
+                as Pin<
+                    Box<
+                        dyn std::future::Future<Output = Result<circles_types::PagedResult<TRow>>>
+                            + Send,
+                    >,
+                >
+        });
+        PagedQuery::new(fetch, params)
+    }
+
     /// circles_getGroupMemberships
-    pub async fn get_memberships(
-        &self,
-        avatar: circles_types::Address,
-    ) -> Result<Vec<GroupMembershipRow>> {
+    pub async fn get_memberships(&self, avatar: Address) -> Result<Vec<GroupMembershipRow>> {
         self.client
             .call("circles_getGroupMemberships", (avatar,))
             .await
     }
 
     /// circles_getGroups
-    pub async fn get_groups(&self, avatar: circles_types::Address) -> Result<Vec<GroupRow>> {
+    pub async fn get_groups(&self, avatar: Address) -> Result<Vec<GroupRow>> {
         self.client.call("circles_getGroups", (avatar,)).await
+    }
+
+    /// Paged `GroupMemberships` query filtered by member address.
+    pub fn get_group_memberships(
+        &self,
+        avatar: Address,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<GroupMembershipRow> {
+        self.paged_query(PagedQueryParams {
+            namespace: "V_CrcV2".into(),
+            table: "GroupMemberships".into(),
+            sort_order,
+            columns: vec![
+                "blockNumber".into(),
+                "timestamp".into(),
+                "transactionIndex".into(),
+                "logIndex".into(),
+                "transactionHash".into(),
+                "group".into(),
+                "member".into(),
+                "expiryTime".into(),
+            ],
+            filter: Some(vec![
+                FilterPredicate::equals("member".into(), format!("{avatar:#x}")).into(),
+            ]),
+            limit,
+        })
+    }
+
+    /// Paged `GroupMemberships` query filtered by group address.
+    pub fn get_group_members(
+        &self,
+        group: Address,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<GroupMembershipRow> {
+        self.paged_query(PagedQueryParams {
+            namespace: "V_CrcV2".into(),
+            table: "GroupMemberships".into(),
+            sort_order,
+            columns: vec![
+                "blockNumber".into(),
+                "timestamp".into(),
+                "transactionIndex".into(),
+                "logIndex".into(),
+                "transactionHash".into(),
+                "group".into(),
+                "member".into(),
+                "expiryTime".into(),
+            ],
+            filter: Some(vec![
+                FilterPredicate::equals("group".into(), format!("{group:#x}")).into(),
+            ]),
+            limit,
+        })
+    }
+
+    /// Paged `Groups` query with optional filters matching the TS helper.
+    pub fn get_groups_paged(
+        &self,
+        limit: u32,
+        params: Option<GroupQueryParams>,
+        sort_order: SortOrder,
+    ) -> PagedQuery<GroupRow> {
+        self.paged_query(PagedQueryParams {
+            namespace: "V_CrcV2".into(),
+            table: "Groups".into(),
+            sort_order,
+            columns: vec![
+                "blockNumber".into(),
+                "timestamp".into(),
+                "transactionIndex".into(),
+                "logIndex".into(),
+                "transactionHash".into(),
+                "group".into(),
+                "type".into(),
+                "owner".into(),
+                "mintPolicy".into(),
+                "mintHandler".into(),
+                "treasury".into(),
+                "service".into(),
+                "feeCollection".into(),
+                "memberCount".into(),
+                "name".into(),
+                "symbol".into(),
+                "cidV0Digest".into(),
+                "erc20WrapperDemurraged".into(),
+                "erc20WrapperStatic".into(),
+            ],
+            filter: build_group_filters(params),
+            limit,
+        })
+    }
+
+    /// Fetch groups across pages until `limit` rows are collected.
+    pub async fn find_groups(
+        &self,
+        limit: u32,
+        params: Option<GroupQueryParams>,
+    ) -> Result<Vec<GroupRow>> {
+        let mut query = self.get_groups_paged(limit, params, SortOrder::DESC);
+        let mut rows = Vec::new();
+
+        while let Some(page) = query.next_page().await? {
+            rows.extend(page.items);
+            if rows.len() as u32 >= limit || !page.has_more {
+                break;
+            }
+        }
+
+        rows.truncate(limit as usize);
+        Ok(rows)
+    }
+}
+
+fn build_group_filters(params: Option<GroupQueryParams>) -> Option<Vec<Filter>> {
+    let params = params?;
+
+    let mut filters = Vec::new();
+
+    if let Some(name_prefix) = params.name_starts_with {
+        filters.push(FilterPredicate::like("name".into(), format!("{name_prefix}%")).into());
+    }
+
+    if let Some(symbol_prefix) = params.symbol_starts_with {
+        filters.push(FilterPredicate::like("symbol".into(), format!("{symbol_prefix}%")).into());
+    }
+
+    if let Some(group_addresses) = params.group_address_in
+        && !group_addresses.is_empty()
+    {
+        let predicates: Vec<Filter> = group_addresses
+            .into_iter()
+            .map(|addr| FilterPredicate::equals("group".into(), format!("{addr:#x}")).into())
+            .collect();
+        filters.push(if predicates.len() == 1 {
+            predicates.into_iter().next().expect("one predicate")
+        } else {
+            Conjunction::or(predicates).into()
+        });
+    }
+
+    if let Some(group_types) = params.group_type_in
+        && !group_types.is_empty()
+    {
+        let predicates: Vec<Filter> = group_types
+            .into_iter()
+            .map(|group_type| FilterPredicate::equals("type".into(), group_type).into())
+            .collect();
+        filters.push(if predicates.len() == 1 {
+            predicates.into_iter().next().expect("one predicate")
+        } else {
+            Conjunction::or(predicates).into()
+        });
+    }
+
+    if let Some(owners) = params.owner_in
+        && !owners.is_empty()
+    {
+        let predicates: Vec<Filter> = owners
+            .into_iter()
+            .map(|addr| FilterPredicate::equals("owner".into(), format!("{addr:#x}")).into())
+            .collect();
+        filters.push(if predicates.len() == 1 {
+            predicates.into_iter().next().expect("one predicate")
+        } else {
+            Conjunction::or(predicates).into()
+        });
+    }
+
+    if let Some(mint_handler) = params.mint_handler_equals {
+        filters.push(
+            FilterPredicate::equals("mintHandler".into(), format!("{mint_handler:#x}")).into(),
+        );
+    }
+
+    if let Some(treasury) = params.treasury_equals {
+        filters.push(FilterPredicate::equals("treasury".into(), format!("{treasury:#x}")).into());
+    }
+
+    if filters.len() > 1 {
+        Some(vec![Conjunction::and(filters).into()])
+    } else if filters.is_empty() {
+        None
+    } else {
+        Some(filters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn methods() -> GroupMethods {
+        let url = "https://rpc.example.com".parse().expect("valid url");
+        GroupMethods::new(RpcClient::http(url))
+    }
+
+    #[test]
+    fn group_memberships_query_uses_membership_table() {
+        let query =
+            methods().get_group_memberships(Address::repeat_byte(0x11), 50, SortOrder::DESC);
+
+        assert_eq!(query.params.namespace, "V_CrcV2");
+        assert_eq!(query.params.table, "GroupMemberships");
+        assert_eq!(query.params.limit, 50);
+    }
+
+    #[test]
+    fn group_filters_match_ts_shape() {
+        let query = methods().get_groups_paged(
+            25,
+            Some(GroupQueryParams {
+                name_starts_with: Some("Comm".into()),
+                symbol_starts_with: None,
+                group_address_in: Some(vec![
+                    Address::repeat_byte(0x22),
+                    Address::repeat_byte(0x33),
+                ]),
+                group_type_in: Some(vec!["Standard".into()]),
+                owner_in: Some(vec![Address::repeat_byte(0x44)]),
+                mint_handler_equals: Some(Address::repeat_byte(0x55)),
+                treasury_equals: None,
+            }),
+            SortOrder::ASC,
+        );
+
+        let filters = query.params.filter.expect("filters");
+        assert_eq!(filters.len(), 1);
+        match &filters[0] {
+            Filter::Conjunction(and) => {
+                assert_eq!(and.predicates.len(), 5);
+            }
+            other => panic!("expected conjunction filter, got {other:?}"),
+        }
     }
 }

--- a/crates/rpc/src/methods/mod.rs
+++ b/crates/rpc/src/methods/mod.rs
@@ -14,6 +14,7 @@ pub mod search;
 pub mod tables;
 pub mod token;
 pub mod token_info;
+pub mod transaction;
 pub mod trust;
 
 pub use avatar::AvatarMethods;
@@ -29,4 +30,5 @@ pub use search::SearchMethods;
 pub use tables::TablesMethods;
 pub use token::TokenMethods;
 pub use token_info::TokenInfoMethods;
+pub use transaction::TransactionMethods;
 pub use trust::TrustMethods;

--- a/crates/rpc/src/methods/transaction.rs
+++ b/crates/rpc/src/methods/transaction.rs
@@ -1,0 +1,196 @@
+use crate::client::RpcClient;
+use crate::error::{CirclesRpcError, Result};
+use crate::methods::QueryMethods;
+use crate::paged_query::{PagedFetch, PagedQuery};
+use circles_types::{
+    Address, Conjunction, FilterPredicate, PagedQueryParams, PagedResult, SortOrder,
+    TransactionHistoryRow, U256,
+};
+use circles_utils::converter::{
+    atto_circles_to_atto_crc, atto_circles_to_atto_static_circles, atto_circles_to_circles,
+};
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawTransactionHistoryRow {
+    block_number: u64,
+    timestamp: u64,
+    transaction_index: u32,
+    log_index: u32,
+    transaction_hash: alloy_primitives::TxHash,
+    version: u32,
+    from: Address,
+    to: Address,
+    id: String,
+    token_address: Address,
+    value: String,
+}
+
+fn enrich_transaction_row(row: RawTransactionHistoryRow) -> Result<TransactionHistoryRow> {
+    let atto_circles =
+        U256::from_str(&row.value).map_err(|e| CirclesRpcError::InvalidResponse {
+            message: format!("invalid transfer summary value: {e}"),
+        })?;
+    let circles = atto_circles_to_circles(atto_circles);
+    let atto_crc = atto_circles_to_atto_crc(atto_circles, row.timestamp);
+    let crc = atto_circles_to_circles(atto_crc);
+    let static_atto_circles =
+        atto_circles_to_atto_static_circles(atto_circles, Some(row.timestamp));
+    let static_circles = atto_circles_to_circles(static_atto_circles);
+
+    Ok(TransactionHistoryRow {
+        block_number: row.block_number,
+        timestamp: row.timestamp,
+        transaction_index: row.transaction_index,
+        log_index: row.log_index,
+        transaction_hash: row.transaction_hash,
+        version: row.version,
+        from: row.from,
+        to: row.to,
+        id: row.id,
+        token_address: row.token_address,
+        value: row.value,
+        circles: Some(circles),
+        atto_circles: Some(atto_circles),
+        static_circles: Some(static_circles),
+        static_atto_circles: Some(static_atto_circles),
+        crc: Some(crc),
+        atto_crc: Some(atto_crc),
+    })
+}
+
+/// Transaction history methods mirroring the TS RPC helper.
+#[derive(Clone, Debug)]
+pub struct TransactionMethods {
+    client: RpcClient,
+}
+
+impl TransactionMethods {
+    /// Create a new accessor for transaction-history RPCs.
+    pub fn new(client: RpcClient) -> Self {
+        Self { client }
+    }
+
+    /// Paged transaction history from the `V_Crc.TransferSummary` view.
+    pub fn get_transaction_history(
+        &self,
+        avatar: Address,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<TransactionHistoryRow> {
+        let params = PagedQueryParams {
+            namespace: "V_Crc".into(),
+            table: "TransferSummary".into(),
+            sort_order,
+            columns: vec![
+                "blockNumber".into(),
+                "timestamp".into(),
+                "transactionIndex".into(),
+                "logIndex".into(),
+                "transactionHash".into(),
+                "version".into(),
+                "from".into(),
+                "to".into(),
+                "id".into(),
+                "tokenAddress".into(),
+                "value".into(),
+            ],
+            filter: Some(vec![
+                Conjunction::and(vec![
+                    FilterPredicate::equals("version".into(), 2).into(),
+                    Conjunction::or(vec![
+                        FilterPredicate::equals("from".into(), format!("{avatar:#x}")).into(),
+                        FilterPredicate::equals("to".into(), format!("{avatar:#x}")).into(),
+                    ])
+                    .into(),
+                ])
+                .into(),
+            ]),
+            limit,
+        };
+
+        let client = self.client.clone();
+        let fetch: PagedFetch<TransactionHistoryRow> = Arc::new(move |params: PagedQueryParams| {
+            let client = client.clone();
+            Box::pin(async move {
+                let raw = QueryMethods::new(client)
+                    .paged_query::<RawTransactionHistoryRow>(params)
+                    .await?;
+                let rows = raw
+                    .results
+                    .into_iter()
+                    .map(enrich_transaction_row)
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(PagedResult {
+                    limit: raw.limit,
+                    size: rows.len() as u32,
+                    first_cursor: raw.first_cursor,
+                    last_cursor: raw.last_cursor,
+                    sort_order: raw.sort_order,
+                    has_more: raw.has_more,
+                    results: rows,
+                })
+            })
+                as Pin<
+                    Box<
+                        dyn std::future::Future<Output = Result<PagedResult<TransactionHistoryRow>>>
+                            + Send,
+                    >,
+                >
+        });
+
+        PagedQuery::new(fetch, params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn methods() -> TransactionMethods {
+        let url = "https://rpc.example.com".parse().expect("valid url");
+        TransactionMethods::new(RpcClient::http(url))
+    }
+
+    #[test]
+    fn transaction_history_query_uses_transfer_summary_view() {
+        let query =
+            methods().get_transaction_history(Address::repeat_byte(0x11), 50, SortOrder::DESC);
+
+        assert_eq!(query.params.namespace, "V_Crc");
+        assert_eq!(query.params.table, "TransferSummary");
+        assert_eq!(query.params.limit, 50);
+    }
+
+    #[test]
+    fn enrich_transaction_row_populates_amount_fields() {
+        let row = enrich_transaction_row(RawTransactionHistoryRow {
+            block_number: 1,
+            timestamp: 1_700_000_000,
+            transaction_index: 2,
+            log_index: 3,
+            transaction_hash: alloy_primitives::TxHash::ZERO,
+            version: 2,
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            id: "1".into(),
+            token_address: Address::repeat_byte(0x33),
+            value: "1000000000000000000".into(),
+        })
+        .expect("enrich");
+
+        assert_eq!(
+            row.atto_circles,
+            Some(U256::from(1_000_000_000_000_000_000u64))
+        );
+        assert!(row.circles.expect("circles") > 0.0);
+        assert!(row.static_circles.expect("static circles") > 0.0);
+        assert!(row.crc.expect("crc") > 0.0);
+        assert!(row.static_atto_circles.expect("static atto") > U256::ZERO);
+        assert!(row.atto_crc.expect("atto crc") > U256::ZERO);
+    }
+}

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -3,7 +3,7 @@ use crate::error::{CirclesRpcError, Result};
 use crate::methods::{
     AvatarMethods, BalanceMethods, EventsMethods, GroupMethods, HealthMethods, InvitationMethods,
     NetworkMethods, PathfinderMethods, QueryMethods, SearchMethods, TablesMethods,
-    TokenInfoMethods, TokenMethods, TrustMethods,
+    TokenInfoMethods, TokenMethods, TransactionMethods, TrustMethods,
 };
 use crate::paged_query::{PagedFetch, PagedQuery};
 use circles_types::PagedQueryParams;
@@ -97,6 +97,10 @@ impl CirclesRpc {
     /// RPC methods for path-finding in the trust graph.
     pub fn pathfinder(&self) -> PathfinderMethods {
         PathfinderMethods::new(self.client.clone())
+    }
+    /// RPC methods for transaction history queries.
+    pub fn transaction(&self) -> TransactionMethods {
+        TransactionMethods::new(self.client.clone())
     }
     /// RPC methods for group lookups.
     pub fn group(&self) -> GroupMethods {

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -13,6 +13,7 @@ The usage model is intentionally simple:
 - Typed avatar helpers for balances, aggregated trust, profiles, pathfinding, transfer planning, replenish planning, and registration flows.
 - Invitation and referral helpers for human avatars.
 - Profile metadata / short-name write helpers plus personal minting for human avatars.
+- Transaction-history pagination for all typed avatars plus human group-membership/detail helpers.
 - Base-group trust/property helpers (`owner`, `mint_handler`, `service`, `fee_collection`, `membership_conditions`, `trust_add_batch_with_conditions`, `set_owner`, `set_service`, `set_fee_collection`, `set_membership_condition`).
 - Human and organisation group-token mint/property helpers (`plan_group_token_mint`, `mint_group_token`, `max_group_token_mintable`, plus group owner/treasury/mint-handler/service/fee-collection lookups).
 - Transfer planning and replenish/max-flow helpers via `circles-transfers` and `circles-pathfinder`.
@@ -77,5 +78,5 @@ All write-capable methods return `SdkError::MissingRunner` until a `ContractRunn
 - Transfer/pathfinding helpers default to wrapped balances; tune `AdvancedTransferOptions` when you need exclusions or simulated balances/trust edges.
 - Avatar wrappers expose `total_balance`, aggregated trust helpers, and `plan_replenish` / `replenish`; human and organisation avatars also expose `max_replenishable` plus `plan_replenish_max` / `replenish_max`.
 - The SDK still uses flatter Rust methods instead of the TS object namespaces (`balances.*`, `trust.*`, `groupToken.*`), so some convenience parity remains outstanding even where the underlying capability now exists.
-- The main remaining facade gaps are direct-transfer/history helpers, group-token redeem/group-membership convenience methods, and the richer TS invitation surface.
+- The main remaining facade gaps are direct-transfer helpers, fuller group-token redeem/member convenience, and the richer TS invitation surface.
 - Generate local rustdoc with `cargo doc -p circles-sdk --all-features`.

--- a/crates/sdk/src/avatar/base_group.rs
+++ b/crates/sdk/src/avatar/base_group.rs
@@ -6,14 +6,14 @@ use crate::{
 use alloy_primitives::{Address, U256, aliases::U96};
 use circles_abis::BaseGroup;
 use circles_profiles::Profiles;
-use circles_rpc::CirclesRpc;
 #[cfg(feature = "ws")]
 use circles_rpc::events::subscription::CirclesSubscription;
+use circles_rpc::{CirclesRpc, PagedQuery};
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
     AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
-    TokenBalanceResponse, TrustRelation,
+    SortOrder, TokenBalanceResponse, TransactionHistoryRow, TrustRelation,
 };
 use std::sync::Arc;
 
@@ -157,6 +157,15 @@ impl BaseGroupAvatar {
     /// Fetch profile (cached by CID in memory).
     pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
         self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    /// Get transaction history for this avatar using cursor-based pagination.
+    pub fn transaction_history(
+        &self,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<TransactionHistoryRow> {
+        self.common.transaction_history(limit, sort_order)
     }
 
     /// Update profile metadata digest on the base group (requires runner).

--- a/crates/sdk/src/avatar/common.rs
+++ b/crates/sdk/src/avatar/common.rs
@@ -3,13 +3,13 @@ use crate::ws;
 use crate::{ContractRunner, Core, PreparedTransaction, Profile, SdkError};
 use alloy_primitives::{Address, U256};
 use circles_profiles::Profiles;
-use circles_rpc::CirclesRpc;
 #[cfg(feature = "ws")]
 use circles_rpc::events::subscription::CirclesSubscription;
+use circles_rpc::{CirclesRpc, PagedQuery};
 use circles_transfers::TransferBuilder;
 use circles_types::{
-    AdvancedTransferOptions, AggregatedTrustRelation, Balance, PathfindingResult,
-    TokenBalanceResponse, TrustRelation, TrustRelationType,
+    AdvancedTransferOptions, AggregatedTrustRelation, Balance, PathfindingResult, SortOrder,
+    TokenBalanceResponse, TransactionHistoryRow, TrustRelation, TrustRelationType,
 };
 #[cfg(feature = "ws")]
 use circles_types::{CirclesEvent, Filter};
@@ -140,6 +140,17 @@ impl CommonAvatar {
         } else {
             Ok(None)
         }
+    }
+
+    /// Get transaction history for this avatar using the shared RPC paged query.
+    pub fn transaction_history(
+        &self,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<TransactionHistoryRow> {
+        self.rpc
+            .transaction()
+            .get_transaction_history(self.address, limit, sort_order)
     }
 
     /// Upload profile to the profile service, returning the new CID.

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -8,14 +8,15 @@ use alloy_primitives::{Address, U256, aliases::U96};
 use alloy_sol_types::{SolCall, SolValue, sol};
 use circles_abis::{HubV2, InvitationFarm, ReferralsModule};
 use circles_profiles::Profiles;
-use circles_rpc::CirclesRpc;
 #[cfg(feature = "ws")]
 use circles_rpc::events::subscription::CirclesSubscription;
+use circles_rpc::{CirclesRpc, PagedQuery};
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
-    AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
-    TokenBalanceResponse, TrustRelation,
+    AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, GroupMembershipRow,
+    GroupQueryParams, GroupRow, PathfindingResult, SortOrder, TokenBalanceResponse,
+    TransactionHistoryRow, TrustRelation,
 };
 use hex::encode as hex_encode;
 use rand::RngCore;
@@ -114,6 +115,15 @@ impl HumanAvatar {
     /// Fetch profile (cached by CID in memory).
     pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
         self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    /// Get transaction history for this avatar using cursor-based pagination.
+    pub fn transaction_history(
+        &self,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<TransactionHistoryRow> {
+        self.common.transaction_history(limit, sort_order)
     }
 
     /// Update profile via profiles service and store CID through NameRegistry (requires runner).
@@ -446,6 +456,56 @@ impl HumanAvatar {
             .call()
             .await
             .map_err(|e| SdkError::Contract(e.to_string()))
+    }
+
+    /// Get group memberships for this avatar using the shared paged-query helper.
+    pub fn group_memberships(
+        &self,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<GroupMembershipRow> {
+        self.common
+            .rpc
+            .group()
+            .get_group_memberships(self.address, limit, sort_order)
+    }
+
+    /// Fetch all group memberships, then resolve full group rows for the referenced groups.
+    ///
+    /// This mirrors the TS helper shape: `limit` is used as the page size for the
+    /// membership query, not as a hard cap on the final enriched result count.
+    pub async fn group_membership_details(&self, limit: u32) -> Result<Vec<GroupRow>, SdkError> {
+        let mut query = self.group_memberships(limit, SortOrder::DESC);
+        let mut memberships = Vec::new();
+
+        while let Some(page) = query.next_page().await? {
+            memberships.extend(page.items);
+            if !page.has_more {
+                break;
+            }
+        }
+
+        if memberships.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let group_addresses = memberships
+            .into_iter()
+            .map(|membership| membership.group)
+            .collect::<Vec<_>>();
+
+        Ok(self
+            .common
+            .rpc
+            .group()
+            .find_groups(
+                group_addresses.len() as u32,
+                Some(GroupQueryParams {
+                    group_address_in: Some(group_addresses),
+                    ..Default::default()
+                }),
+            )
+            .await?)
     }
 
     /// Mint all currently claimable personal tokens (requires runner).

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -6,14 +6,14 @@ use crate::{
 use alloy_primitives::{Address, U256, aliases::U96};
 use circles_abis::HubV2;
 use circles_profiles::Profiles;
-use circles_rpc::CirclesRpc;
 #[cfg(feature = "ws")]
 use circles_rpc::events::subscription::CirclesSubscription;
+use circles_rpc::{CirclesRpc, PagedQuery};
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
     AdvancedTransferOptions, AggregatedTrustRelation, AvatarInfo, Balance, PathfindingResult,
-    TokenBalanceResponse, TrustRelation,
+    SortOrder, TokenBalanceResponse, TransactionHistoryRow, TrustRelation,
 };
 use std::sync::Arc;
 
@@ -90,6 +90,15 @@ impl OrganisationAvatar {
     /// Fetch profile (cached by CID in memory).
     pub async fn profile(&self) -> Result<Option<Profile>, SdkError> {
         self.common.profile(self.info.cid_v0.as_deref()).await
+    }
+
+    /// Get transaction history for this avatar using cursor-based pagination.
+    pub fn transaction_history(
+        &self,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<TransactionHistoryRow> {
+        self.common.transaction_history(limit, sort_order)
     }
 
     /// Update profile via profiles service and store CID through NameRegistry (requires runner).

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -199,7 +199,7 @@ pub use runner::{BatchRun, ContractRunner, RunnerConfig};
 mod rpc;
 pub use rpc::{
     Balance, CirclesQueryResponse, JsonRpcError, JsonRpcRequest, JsonRpcResponse, QueryResponse,
-    SafeQueryResponse, TokenBalanceResponse,
+    SafeQueryResponse, TokenBalanceResponse, TransactionHistoryRow,
 };
 
 mod query;

--- a/crates/types/src/rpc.rs
+++ b/crates/types/src/rpc.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, TxHash, U256};
 use serde::{Deserialize, Serialize};
 
 /// JSON-RPC request structure
@@ -139,4 +139,33 @@ pub struct TokenBalanceResponse {
     #[serde(default, rename = "staticCircles")]
     pub static_circles: Option<f64>,
     pub token_owner: Address,
+}
+
+/// Transaction history row matching the TS RPC helper shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionHistoryRow {
+    pub block_number: u64,
+    pub timestamp: u64,
+    pub transaction_index: u32,
+    pub log_index: u32,
+    pub transaction_hash: TxHash,
+    pub version: u32,
+    pub from: Address,
+    pub to: Address,
+    pub id: String,
+    pub token_address: Address,
+    pub value: String,
+    #[serde(default)]
+    pub circles: Option<f64>,
+    #[serde(default)]
+    pub atto_circles: Option<U256>,
+    #[serde(default)]
+    pub static_circles: Option<f64>,
+    #[serde(default)]
+    pub static_atto_circles: Option<U256>,
+    #[serde(default)]
+    pub crc: Option<f64>,
+    #[serde(default)]
+    pub atto_crc: Option<U256>,
 }

--- a/crates/utils/src/converter.rs
+++ b/crates/utils/src/converter.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::U256;
 use num_bigint::BigUint;
-use num_traits::Zero;
+use num_traits::{ToPrimitive, Zero};
 
 /// Demurrage/inflation conversion helpers ported from the TS CirclesConverter.
 /// We use 1e36-scaled factors (GAMMA_36/BETA_36) to avoid overflow and match
@@ -22,6 +22,10 @@ fn one_36() -> BigUint {
 
 const SECONDS_PER_DAY: u64 = 86_400;
 const INFLATION_DAY_ZERO_UNIX: u64 = 1_602_720_000; // 2020-10-15 00:00:00 UTC
+const V1_ACCURACY: u64 = 100_000_000; // 1e8
+const V1_INFLATION_PCT_NUM: u64 = 107;
+const V1_INFLATION_PCT_DEN: u64 = 100;
+const PERIOD_SEC: u64 = 31_556_952; // 365.25 days
 
 /// UNIX timestamp (seconds) → Circles day index (can be negative if before day zero).
 pub fn day_from_timestamp(unix_seconds: u64) -> i64 {
@@ -64,6 +68,15 @@ fn big_to_u256(val: BigUint) -> U256 {
     U256::from_limbs(limbs)
 }
 
+fn v1_inflate_factor(period_idx: u64) -> BigUint {
+    if period_idx == 0 {
+        return BigUint::from(V1_ACCURACY);
+    }
+    let num = BigUint::from(V1_INFLATION_PCT_NUM).pow(period_idx as u32);
+    let den = BigUint::from(V1_INFLATION_PCT_DEN).pow(period_idx as u32);
+    (BigUint::from(V1_ACCURACY) * num) / den
+}
+
 /// Demurraged atto-circles → static atto-circles for a given timestamp.
 ///
 /// If `now_unix_seconds` is `None`, uses the current time. Negative day indices
@@ -98,6 +111,39 @@ pub fn atto_static_circles_to_atto_circles(
     let infl = u256_to_big(static_circles);
     let dem = (infl * factor) / one_36();
     big_to_u256(dem)
+}
+
+/// Demurraged atto-circles → UI circles as `f64`.
+pub fn atto_circles_to_circles(atto: U256) -> f64 {
+    if atto.is_zero() {
+        return 0.0;
+    }
+
+    let big = u256_to_big(atto);
+    let scale = BigUint::from(1_000_000_000_000_000_000u64);
+    let whole = &big / &scale;
+    let frac = &big % &scale;
+
+    whole.to_f64().unwrap_or(f64::INFINITY) + frac.to_f64().unwrap_or(0.0) / 1e18
+}
+
+/// Demurraged atto-circles → inflationary CRC amount at the provided timestamp.
+pub fn atto_circles_to_atto_crc(demurraged: U256, block_timestamp_utc: u64) -> U256 {
+    let seconds_since_epoch = block_timestamp_utc.saturating_sub(INFLATION_DAY_ZERO_UNIX);
+    let period_idx = seconds_since_epoch / PERIOD_SEC;
+    let seconds_into_period = seconds_since_epoch % PERIOD_SEC;
+
+    let factor_cur = v1_inflate_factor(period_idx);
+    let factor_next = v1_inflate_factor(period_idx + 1);
+
+    let period = BigUint::from(PERIOD_SEC);
+    let seconds_into = BigUint::from(seconds_into_period);
+    let r_p = (&factor_cur * (BigUint::from(PERIOD_SEC) - &seconds_into))
+        + (&factor_next * &seconds_into);
+
+    let numerator =
+        u256_to_big(demurraged) * BigUint::from(3u64) * BigUint::from(V1_ACCURACY) * &period;
+    big_to_u256(numerator / r_p)
 }
 
 fn now_ts() -> u64 {


### PR DESCRIPTION
## Summary
- add shared transaction-history row types and RPC paged-query helpers for transfer history and group queries
- expose typed avatar history helpers plus human group-membership detail helpers in circles-sdk
- update the parity snapshot and SDK docs for the new read-surface coverage

## Validation
- cargo check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test