### PR TITLE
feat: add group token redeem and holder parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ As of March 26, 2026, this workspace is closer to the TypeScript SDK, but it is 
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place, including paged transaction history plus group-membership/group-query helpers used by the higher-level crates. |
+| `circles-rpc` | Good coverage | Core HTTP/query/event decoding is in place, including paged transaction history plus the flexible cursor/order pagination needed for group membership, group queries, and group-holder views. |
 | `circles-pathfinder` | Close | Recent parity work aligned flow-matrix terminal edges, wrapped-token rewriting, token-info helpers, netted-flow helpers, and explicit RPC/client entrypoints. |
-| `circles-transfers` | Close | Advanced transfer planning, aggregate transfers, and the TS-style `constructReplenish` flow are present; remaining work is mostly higher-level parity polish and broader behavioral coverage. |
-| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, direct-transfer planning/execution, transaction-history pagination, profile metadata / short-name writes, personal minting, max-replenish helpers, base-group read/write helpers, human group-membership detail helpers, and group-token mint/property helpers; fuller group-token parity and wallet-backend parity are still incomplete. |
+| `circles-transfers` | Close | Advanced transfer planning, aggregate transfers, the TS-style `constructReplenish` flow, and the automatic group-token redeem planner are present; remaining work is mostly higher-level parity polish and broader behavioral coverage. |
+| `circles-sdk` | Partial, improving | Read flows and typed avatars are usable, replenish planning/execution rides the runner abstraction, and the convenience surface now covers aggregated trust helpers, direct-transfer planning/execution, transaction-history pagination, profile metadata / short-name writes, personal minting, max-replenish helpers, base-group read/write helpers, human group-membership detail helpers, top-level group member/collateral/holder reads, and group-token mint/redeem/property helpers; wallet-backend parity and the richer invitation facade are still incomplete. |
 | `circles-profiles`, `circles-utils`, `circles-types`, `circles-abis` | Supporting / lower risk | These crates are in service for the current SDK flows and are not the main parity bottlenecks right now. |
 
-The biggest remaining parity work is no longer the replenish planner itself. The open gaps are the rest of the higher-level SDK facade and execution-backend parity, especially fuller group-token redeem/member convenience, the richer invitation surface, and wallet-specific flows outside the generic runner abstraction.
+The biggest remaining parity work is no longer the replenish planner or group convenience. The open gaps are the last higher-level SDK facade edges and execution-backend parity, especially the richer invitation / referral surface and wallet-specific flows outside the generic runner abstraction.
 
 ## Usage model
 

--- a/crates/rpc/examples/paged_and_ws.rs
+++ b/crates/rpc/examples/paged_and_ws.rs
@@ -37,6 +37,8 @@ async fn main() -> Result<()> {
         sort_order: SortOrder::DESC,
         columns: vec!["avatar".into(), "timestamp".into()],
         filter: None,
+        cursor_columns: None,
+        order_columns: None,
         limit: 10,
     };
 

--- a/crates/rpc/src/methods/group.rs
+++ b/crates/rpc/src/methods/group.rs
@@ -3,8 +3,8 @@ use crate::error::Result;
 use crate::methods::QueryMethods;
 use crate::paged_query::{PagedFetch, PagedQuery};
 use circles_types::{
-    Address, Conjunction, Filter, FilterPredicate, GroupMembershipRow, GroupQueryParams, GroupRow,
-    PagedQueryParams, SortOrder,
+    Address, Conjunction, CursorColumn, Filter, FilterPredicate, GroupMembershipRow,
+    GroupQueryParams, GroupRow, GroupTokenHolderRow, OrderBy, PagedQueryParams, SortOrder,
 };
 use std::pin::Pin;
 use std::sync::Arc;
@@ -82,6 +82,8 @@ impl GroupMethods {
             filter: Some(vec![
                 FilterPredicate::equals("member".into(), format!("{avatar:#x}")).into(),
             ]),
+            cursor_columns: None,
+            order_columns: None,
             limit,
         })
     }
@@ -109,6 +111,33 @@ impl GroupMethods {
             ],
             filter: Some(vec![
                 FilterPredicate::equals("group".into(), format!("{group:#x}")).into(),
+            ]),
+            cursor_columns: None,
+            order_columns: None,
+            limit,
+        })
+    }
+
+    /// Paged `GroupTokenHoldersBalance` query matching the TS group holders helper.
+    pub fn get_group_holders(&self, group: Address, limit: u32) -> PagedQuery<GroupTokenHolderRow> {
+        self.paged_query(PagedQueryParams {
+            namespace: "V_CrcV2".into(),
+            table: "GroupTokenHoldersBalance".into(),
+            sort_order: SortOrder::DESC,
+            columns: vec![
+                "group".into(),
+                "holder".into(),
+                "totalBalance".into(),
+                "demurragedTotalBalance".into(),
+                "fractionOwnership".into(),
+            ],
+            filter: Some(vec![
+                FilterPredicate::equals("group".into(), format!("{group:#x}")).into(),
+            ]),
+            cursor_columns: Some(vec![CursorColumn::asc("holder".into())]),
+            order_columns: Some(vec![
+                OrderBy::desc("totalBalance".into()),
+                OrderBy::asc("holder".into()),
             ]),
             limit,
         })
@@ -147,6 +176,8 @@ impl GroupMethods {
                 "erc20WrapperStatic".into(),
             ],
             filter: build_group_filters(params),
+            cursor_columns: None,
+            order_columns: None,
             limit,
         })
     }
@@ -292,5 +323,24 @@ mod tests {
             }
             other => panic!("expected conjunction filter, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn group_holders_query_matches_ts_cursor_and_order_shape() {
+        let query = methods().get_group_holders(Address::repeat_byte(0x66), 10);
+
+        assert_eq!(query.params.table, "GroupTokenHoldersBalance");
+        assert_eq!(query.params.sort_order, SortOrder::DESC);
+        assert_eq!(
+            query.params.cursor_columns,
+            Some(vec![CursorColumn::asc("holder".into())])
+        );
+        assert_eq!(
+            query.params.order_columns,
+            Some(vec![
+                OrderBy::desc("totalBalance".into()),
+                OrderBy::asc("holder".into()),
+            ])
+        );
     }
 }

--- a/crates/rpc/src/methods/query.rs
+++ b/crates/rpc/src/methods/query.rs
@@ -1,6 +1,8 @@
 use crate::client::RpcClient;
 use crate::error::{CirclesRpcError, Result};
-use circles_types::{CirclesQueryResponse, OrderBy, PagedQueryParams, PagedResult, QueryParams};
+use circles_types::{
+    CirclesQueryResponse, Cursor, CursorColumn, OrderBy, PagedQueryParams, PagedResult, QueryParams,
+};
 use serde_json::Value;
 
 /// Methods for issuing `circles_query` requests and decoding the tabular response.
@@ -47,17 +49,29 @@ impl QueryMethods {
             sort_order,
             columns,
             filter,
+            cursor_columns,
+            order_columns,
             limit,
         } = params.clone();
 
-        // Convert to QueryParams. If the caller supplied an order, we would add it here; for now
-        // we ensure stable ordering via block/tx/log and timestamp.
-        let mut order: Vec<OrderBy> = Vec::new();
-        let dir = sort_order.clone();
-        order.push(OrderBy::new("blockNumber".to_string(), dir.clone()));
-        order.push(OrderBy::new("transactionIndex".to_string(), dir.clone()));
-        order.push(OrderBy::new("logIndex".to_string(), dir.clone()));
-        order.push(OrderBy::new("timestamp".to_string(), dir));
+        let order: Vec<OrderBy> = if let Some(order_columns) = order_columns.clone() {
+            if order_columns.is_empty() {
+                params.resolved_order_columns()
+            } else {
+                order_columns
+            }
+        } else {
+            params.resolved_order_columns()
+        };
+        let cursor_columns = if let Some(cursor_columns) = cursor_columns {
+            if cursor_columns.is_empty() {
+                params.resolved_cursor_columns()
+            } else {
+                cursor_columns
+            }
+        } else {
+            params.resolved_cursor_columns()
+        };
 
         let query_params = QueryParams {
             namespace,
@@ -72,7 +86,7 @@ impl QueryMethods {
             self.client.call("circles_query", (query_params,)).await?;
 
         let rows = self.decode_rows::<TRow>(result.columns.clone(), result.rows.clone())?;
-        let cursors = self.extract_cursors(&result.columns, &result.rows);
+        let cursors = self.extract_cursors(&result.columns, &result.rows, &cursor_columns);
         let first_cursor = cursors.first().cloned();
         let last_cursor = cursors.last().cloned();
         let size = rows.len() as u32;
@@ -124,18 +138,26 @@ impl QueryMethods {
         &self,
         columns: &[String],
         rows: &[Vec<Value>],
-    ) -> Vec<circles_types::Cursor> {
+        cursor_columns: &[CursorColumn],
+    ) -> Vec<Cursor> {
         rows.iter()
-            .filter_map(|row| self.extract_cursor(columns, row))
+            .filter_map(|row| self.extract_cursor(columns, row, cursor_columns))
             .collect()
     }
 
-    fn extract_cursor(&self, columns: &[String], row: &[Value]) -> Option<circles_types::Cursor> {
+    fn extract_cursor(
+        &self,
+        columns: &[String],
+        row: &[Value],
+        cursor_columns: &[CursorColumn],
+    ) -> Option<Cursor> {
         let mut block_number: Option<u64> = None;
         let mut tx_index: Option<u32> = None;
         let mut log_index: Option<u32> = None;
         let mut batch_index: Option<u32> = None;
         let mut timestamp: Option<u64> = None;
+        let mut cursor = Cursor::default();
+        let mut has_cursor_values = false;
 
         for (col, val) in columns.iter().zip(row.iter()) {
             match col.as_str() {
@@ -146,18 +168,27 @@ impl QueryMethods {
                 "timestamp" => timestamp = Self::as_u64(val),
                 _ => {}
             }
+
+            if cursor_columns.iter().any(|column| column.name == *col) {
+                cursor.insert_value(col.clone(), val.clone());
+                has_cursor_values = true;
+            }
         }
 
-        match (block_number, tx_index, log_index) {
-            (Some(b), Some(tx), Some(log)) => Some(circles_types::Cursor {
-                block_number: b,
-                transaction_index: tx,
-                log_index: log,
-                batch_index,
-                timestamp,
-            }),
-            _ => None,
+        if let (Some(b), Some(tx), Some(log)) = (block_number, tx_index, log_index) {
+            cursor.block_number = b;
+            cursor.transaction_index = tx;
+            cursor.log_index = log;
+            cursor.batch_index = batch_index;
+            cursor.timestamp = timestamp;
+            return Some(cursor);
         }
+
+        if has_cursor_values {
+            return Some(cursor);
+        }
+
+        None
     }
 
     fn as_u64(val: &Value) -> Option<u64> {

--- a/crates/rpc/src/methods/transaction.rs
+++ b/crates/rpc/src/methods/transaction.rs
@@ -110,6 +110,8 @@ impl TransactionMethods {
                 ])
                 .into(),
             ]),
+            cursor_columns: None,
+            order_columns: None,
             limit,
         };
 

--- a/crates/rpc/src/paged_query.rs
+++ b/crates/rpc/src/paged_query.rs
@@ -1,10 +1,12 @@
 use crate::error::Result;
 use circles_types::{
-    Cursor, Filter, FilterPredicate, FilterType, PagedQueryParams, PagedResult, SortOrder,
+    Conjunction, Cursor, CursorColumn, Filter, FilterPredicate, FilterType, PagedQueryParams,
+    PagedResult, SortOrder,
 };
 use futures::{Stream, StreamExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde_json::Value;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -55,32 +57,9 @@ where
     pub async fn next_page(&mut self) -> Result<Option<Page<TRow>>> {
         let mut params = self.params.clone();
 
-        // Inject cursor filters if a cursor is present.
         if let Some(cursor) = &self.current_cursor {
-            let cmp = match params.sort_order {
-                SortOrder::ASC => FilterType::GreaterOrEqualThan,
-                SortOrder::DESC => FilterType::LessOrEqualThan,
-            };
-            let mut filters: Vec<Filter> = params.filter.unwrap_or_default();
-            filters.push(
-                FilterPredicate::new(cmp.clone(), "blockNumber".to_string(), cursor.block_number)
-                    .into(),
-            );
-            filters.push(
-                FilterPredicate::new(
-                    cmp.clone(),
-                    "transactionIndex".to_string(),
-                    cursor.transaction_index,
-                )
-                .into(),
-            );
-            filters.push(
-                FilterPredicate::new(cmp.clone(), "logIndex".to_string(), cursor.log_index).into(),
-            );
-            if let Some(batch) = cursor.batch_index {
-                filters.push(FilterPredicate::new(cmp, "batchIndex".to_string(), batch).into());
-            }
-            params.filter = Some(filters);
+            let cursor_filter = build_cursor_filter(cursor, &params.resolved_cursor_columns());
+            params.filter = combine_filters(params.filter.take(), cursor_filter);
         }
 
         let result = (self.fetch)(params).await?;
@@ -121,5 +100,215 @@ where
             Ok(vec) => futures::stream::iter(vec.into_iter().map(Ok)).boxed(),
             Err(err) => futures::stream::iter(vec![Err(err)]).boxed(),
         })
+    }
+}
+
+fn build_cursor_filter(cursor: &Cursor, cursor_columns: &[CursorColumn]) -> Vec<Filter> {
+    let mut or_predicates = Vec::new();
+
+    for level in 0..cursor_columns.len() {
+        let current_column = &cursor_columns[level];
+        let Some(cursor_value) = cursor_column_value(cursor, &current_column.name) else {
+            continue;
+        };
+
+        if level == 0 {
+            or_predicates.push(comparison_predicate(current_column, cursor_value));
+            continue;
+        }
+
+        let mut and_predicates = Vec::new();
+        for previous_column in cursor_columns.iter().take(level) {
+            let Some(previous_value) = cursor_column_value(cursor, &previous_column.name) else {
+                continue;
+            };
+            and_predicates
+                .push(FilterPredicate::equals(previous_column.name.clone(), previous_value).into());
+        }
+        and_predicates.push(comparison_predicate(current_column, cursor_value));
+        or_predicates.push(Conjunction::and(and_predicates).into());
+    }
+
+    if or_predicates.is_empty() {
+        Vec::new()
+    } else {
+        vec![Conjunction::or(or_predicates).into()]
+    }
+}
+
+fn combine_filters(
+    base_filters: Option<Vec<Filter>>,
+    cursor_filter: Vec<Filter>,
+) -> Option<Vec<Filter>> {
+    match (base_filters, cursor_filter.is_empty()) {
+        (None, true) => None,
+        (Some(filters), true) => Some(filters),
+        (None, false) => Some(cursor_filter),
+        (Some(base_filters), false) => {
+            let mut predicates = base_filters;
+            predicates.extend(cursor_filter);
+            Some(vec![Conjunction::and(predicates).into()])
+        }
+    }
+}
+
+fn comparison_predicate(column: &CursorColumn, value: Value) -> Filter {
+    let filter_type = match column.sort_order {
+        SortOrder::ASC => FilterType::GreaterThan,
+        SortOrder::DESC => FilterType::LessThan,
+    };
+    FilterPredicate::new(filter_type, column.name.clone(), value).into()
+}
+
+fn cursor_column_value(cursor: &Cursor, column: &str) -> Option<Value> {
+    match column {
+        "blockNumber" => Some(
+            cursor
+                .value(column)
+                .cloned()
+                .unwrap_or_else(|| Value::from(cursor.block_number)),
+        ),
+        "transactionIndex" => Some(
+            cursor
+                .value(column)
+                .cloned()
+                .unwrap_or_else(|| Value::from(cursor.transaction_index)),
+        ),
+        "logIndex" => Some(
+            cursor
+                .value(column)
+                .cloned()
+                .unwrap_or_else(|| Value::from(cursor.log_index)),
+        ),
+        "batchIndex" => cursor
+            .value(column)
+            .cloned()
+            .or_else(|| cursor.batch_index.map(Value::from)),
+        "timestamp" => cursor
+            .value(column)
+            .cloned()
+            .or_else(|| cursor.timestamp.map(Value::from)),
+        _ => cursor.value(column).cloned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct HolderRow {
+        group: String,
+        holder: String,
+        #[serde(rename = "totalBalance")]
+        total_balance: String,
+        #[serde(rename = "demurragedTotalBalance")]
+        demurraged_total_balance: String,
+        #[serde(rename = "fractionOwnership")]
+        fraction_ownership: f64,
+    }
+
+    #[tokio::test]
+    async fn next_page_builds_ts_style_custom_cursor_filter() {
+        let seen_params = Arc::new(Mutex::new(Vec::<PagedQueryParams>::new()));
+        let seen_params_fetch = Arc::clone(&seen_params);
+        let fetch: PagedFetch<HolderRow> = Arc::new(move |params: PagedQueryParams| {
+            let seen_params = Arc::clone(&seen_params_fetch);
+            Box::pin(async move {
+                let call_index = {
+                    let mut guard = seen_params.lock().expect("lock params");
+                    guard.push(params.clone());
+                    guard.len()
+                };
+
+                if call_index == 1 {
+                    let mut cursor = Cursor::default();
+                    cursor.insert_value(
+                        "holder".to_string(),
+                        json!("0x2222222222222222222222222222222222222222"),
+                    );
+
+                    Ok(PagedResult {
+                        limit: params.limit,
+                        size: 1,
+                        first_cursor: Some(cursor.clone()),
+                        last_cursor: Some(cursor),
+                        sort_order: params.sort_order,
+                        has_more: true,
+                        results: vec![HolderRow {
+                            group: "0x1111111111111111111111111111111111111111".into(),
+                            holder: "0x2222222222222222222222222222222222222222".into(),
+                            total_balance: "100".into(),
+                            demurraged_total_balance: "100".into(),
+                            fraction_ownership: 0.5,
+                        }],
+                    })
+                } else {
+                    Ok(PagedResult {
+                        limit: params.limit,
+                        size: 0,
+                        first_cursor: None,
+                        last_cursor: None,
+                        sort_order: params.sort_order,
+                        has_more: false,
+                        results: Vec::new(),
+                    })
+                }
+            })
+        });
+
+        let mut query = PagedQuery::new(
+            fetch,
+            PagedQueryParams {
+                namespace: "V_CrcV2".into(),
+                table: "GroupTokenHoldersBalance".into(),
+                sort_order: SortOrder::DESC,
+                columns: vec![
+                    "group".into(),
+                    "holder".into(),
+                    "totalBalance".into(),
+                    "demurragedTotalBalance".into(),
+                    "fractionOwnership".into(),
+                ],
+                filter: Some(vec![
+                    FilterPredicate::equals(
+                        "group".into(),
+                        "0x1111111111111111111111111111111111111111",
+                    )
+                    .into(),
+                ]),
+                cursor_columns: Some(vec![CursorColumn::asc("holder".into())]),
+                order_columns: Some(vec![
+                    circles_types::OrderBy::desc("totalBalance".into()),
+                    circles_types::OrderBy::asc("holder".into()),
+                ]),
+                limit: 50,
+            },
+        );
+
+        assert!(query.next_page().await.expect("first page").is_some());
+        assert!(query.next_page().await.expect("second page").is_none());
+
+        let recorded = seen_params.lock().expect("lock params");
+        assert_eq!(recorded.len(), 2);
+        let second_filter = serde_json::to_value(recorded[1].filter.clone().expect("filter"))
+            .expect("serialize filter");
+        assert_eq!(second_filter[0]["Type"], json!("Conjunction"));
+        assert_eq!(second_filter[0]["ConjunctionType"], json!("And"));
+        assert_eq!(
+            second_filter[0]["Predicates"][1]["ConjunctionType"],
+            json!("Or")
+        );
+        assert_eq!(
+            second_filter[0]["Predicates"][1]["Predicates"][0]["Column"],
+            json!("holder")
+        );
+        assert_eq!(
+            second_filter[0]["Predicates"][1]["Predicates"][0]["FilterType"],
+            json!("GreaterThan")
+        );
     }
 }

--- a/crates/rpc/src/utils.rs
+++ b/crates/rpc/src/utils.rs
@@ -38,12 +38,29 @@ pub trait CursorLike {
 
 impl CursorLike for EventRow {
     fn to_cursor(&self) -> Cursor {
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            "blockNumber".to_string(),
+            serde_json::json!(self.block_number),
+        );
+        values.insert(
+            "transactionIndex".to_string(),
+            serde_json::json!(self.transaction_index),
+        );
+        values.insert("logIndex".to_string(), serde_json::json!(self.log_index));
+        if let Some(batch_index) = self.batch_index {
+            values.insert("batchIndex".to_string(), serde_json::json!(batch_index));
+        }
+        if let Some(timestamp) = self.timestamp {
+            values.insert("timestamp".to_string(), serde_json::json!(timestamp));
+        }
         Cursor {
             block_number: self.block_number,
             transaction_index: self.transaction_index,
             log_index: self.log_index,
             batch_index: self.batch_index,
             timestamp: self.timestamp,
+            values,
         }
     }
 }

--- a/crates/rpc/tests/query_decode.rs
+++ b/crates/rpc/tests/query_decode.rs
@@ -1,6 +1,6 @@
 use circles_rpc::RpcClient;
 use circles_rpc::methods::QueryMethods;
-use circles_types::{PagedQueryParams, SortOrder};
+use circles_types::{CursorColumn, OrderBy, PagedQueryParams, SortOrder};
 use serde_json::{Value, json};
 
 // Helper: construct a QueryMethods with a dummy RpcClient; we only use its decode helpers.
@@ -34,7 +34,15 @@ fn decode_circles_query_rows() {
     );
 
     // Ensure cursors extract correctly.
-    let cursors = methods.extract_cursors(&columns, &rows);
+    let cursor_columns = PagedQueryParams::new(
+        "V_Crc".to_string(),
+        "TransferSummary".to_string(),
+        SortOrder::DESC,
+        columns.clone(),
+        rows.len() as u32,
+    )
+    .resolved_cursor_columns();
+    let cursors = methods.extract_cursors(&columns, &rows, &cursor_columns);
     assert_eq!(cursors.len(), 2);
     assert_eq!(cursors[0].block_number, 30000000);
     assert_eq!(cursors[0].transaction_index, 1);
@@ -57,7 +65,15 @@ fn paged_query_has_more_logic() {
         vec![json!(10), json!(0), json!(0), json!(1700), json!("0x1")],
         vec![json!(9), json!(1), json!(0), json!(1699), json!("0x2")],
     ];
-    let cursors = methods.extract_cursors(&columns, &rows);
+    let cursor_columns = PagedQueryParams::new(
+        "V_Crc".to_string(),
+        "Avatars".to_string(),
+        SortOrder::DESC,
+        columns.clone(),
+        rows.len() as u32,
+    )
+    .resolved_cursor_columns();
+    let cursors = methods.extract_cursors(&columns, &rows, &cursor_columns);
     assert_eq!(cursors.len(), 2);
     assert_eq!(cursors[1].timestamp, Some(1699));
 
@@ -67,6 +83,8 @@ fn paged_query_has_more_logic() {
         sort_order: SortOrder::DESC,
         columns: vec!["avatar".to_string()],
         filter: None,
+        cursor_columns: None,
+        order_columns: None,
         limit: 2,
     };
 
@@ -93,7 +111,15 @@ fn extract_cursor_with_batch_index() {
         .collect();
 
     let methods = query_methods();
-    let cursors = methods.extract_cursors(&columns, &rows);
+    let cursor_columns = PagedQueryParams::new(
+        "V_Crc".to_string(),
+        "TransferBatch".to_string(),
+        SortOrder::DESC,
+        columns.clone(),
+        rows.len() as u32,
+    )
+    .resolved_cursor_columns();
+    let cursors = methods.extract_cursors(&columns, &rows, &cursor_columns);
     assert_eq!(cursors.len(), 1);
     let cursor = &cursors[0];
     assert_eq!(cursor.block_number, 40000000);
@@ -101,4 +127,45 @@ fn extract_cursor_with_batch_index() {
     assert_eq!(cursor.log_index, 7);
     assert_eq!(cursor.batch_index, Some(3));
     assert_eq!(cursor.timestamp, Some(1715000000));
+}
+
+#[test]
+fn extract_cursor_with_custom_cursor_columns() {
+    let columns = vec![
+        "group".to_string(),
+        "holder".to_string(),
+        "totalBalance".to_string(),
+        "demurragedTotalBalance".to_string(),
+        "fractionOwnership".to_string(),
+    ];
+    let rows = vec![vec![
+        json!("0x1111111111111111111111111111111111111111"),
+        json!("0x2222222222222222222222222222222222222222"),
+        json!("100"),
+        json!("100"),
+        json!(0.5),
+    ]];
+
+    let methods = query_methods();
+    let cursor_columns = vec![CursorColumn::asc("holder".into())];
+    let cursors = methods.extract_cursors(&columns, &rows, &cursor_columns);
+    assert_eq!(cursors.len(), 1);
+    assert_eq!(
+        cursors[0].value("holder"),
+        Some(&json!("0x2222222222222222222222222222222222222222"))
+    );
+
+    let params = PagedQueryParams::new(
+        "V_CrcV2".into(),
+        "GroupTokenHoldersBalance".into(),
+        SortOrder::DESC,
+        columns,
+        50,
+    )
+    .with_cursor_columns(cursor_columns.clone())
+    .with_order_columns(vec![
+        OrderBy::desc("totalBalance".into()),
+        OrderBy::asc("holder".into()),
+    ]);
+    assert_eq!(params.resolved_cursor_columns(), cursor_columns);
 }

--- a/crates/rpc/tests/token_decode.rs
+++ b/crates/rpc/tests/token_decode.rs
@@ -15,3 +15,45 @@ fn decode_token_balances() {
         _ => panic!("expected raw balance"),
     }
 }
+
+#[test]
+fn decode_rich_token_balance_payload() {
+    let raw: Vec<TokenBalanceResponse> = serde_json::from_str(
+        r#"
+        [
+          {
+            "tokenAddress": "0x1234567890abcdef1234567890abcdef12345678",
+            "tokenId": "0x1234567890abcdef1234567890abcdef12345678",
+            "tokenOwner": "0xabcdef1234567890abcdef1234567890abcdef12",
+            "tokenType": "CrcV2_RegisterHuman",
+            "version": 2,
+            "attoCircles": "1000000000000000000",
+            "circles": 1.0,
+            "staticAttoCircles": "1000000000000000000",
+            "staticCircles": 1.0,
+            "attoCrc": "1000000000000000000",
+            "crc": 1.0,
+            "isErc20": false,
+            "isErc1155": true,
+            "isWrapped": false,
+            "isInflationary": false,
+            "isGroup": false
+          }
+        ]
+        "#,
+    )
+    .expect("parse rich token balances");
+
+    assert_eq!(raw.len(), 1);
+    assert_eq!(raw[0].token_address, raw[0].token_id);
+    assert_eq!(raw[0].token_type.as_deref(), Some("CrcV2_RegisterHuman"));
+    assert_eq!(raw[0].version, Some(2));
+    assert!(raw[0].is_erc1155);
+    match raw[0].balance {
+        Balance::Raw(v) => assert_eq!(
+            v,
+            alloy_primitives::U256::from(1_000_000_000_000_000_000u128)
+        ),
+        _ => panic!("expected raw balance"),
+    }
+}

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -10,12 +10,13 @@ The usage model is intentionally simple:
 
 ## Capabilities
 
-- Typed avatar helpers for balances, aggregated trust, profiles, direct-transfer planning/execution, pathfinding, replenish planning, and registration flows.
+- Typed avatar helpers for balances, aggregated trust, profiles, direct-transfer planning/execution, pathfinding, replenish planning, group-token redeem planning/execution, and registration flows.
 - Invitation and referral helpers for human avatars.
 - Profile metadata / short-name write helpers plus personal minting for human avatars.
 - Transaction-history pagination for all typed avatars plus human group-membership/detail helpers.
 - Base-group trust/property helpers (`owner`, `mint_handler`, `service`, `fee_collection`, `membership_conditions`, `trust_add_batch_with_conditions`, `set_owner`, `set_service`, `set_fee_collection`, `set_membership_condition`).
-- Human and organisation group-token mint/property helpers (`plan_group_token_mint`, `mint_group_token`, `max_group_token_mintable`, plus group owner/treasury/mint-handler/service/fee-collection lookups).
+- Human and organisation group-token mint/redeem/property helpers (`plan_group_token_mint`, `mint_group_token`, `max_group_token_mintable`, `plan_group_token_redeem`, `redeem_group_token`, plus group owner/treasury/mint-handler/service/fee-collection lookups).
+- Top-level SDK group convenience for `group_members`, `group_collateral`, and `group_holders`.
 - Transfer planning and replenish/max-flow helpers via `circles-transfers` and `circles-pathfinder`.
 - Optional WebSocket subscriptions with retry/backoff and HTTP catch-up through the `ws` feature.
 - Shared mainnet config through `config::gnosis_mainnet()` and `GNOSIS_MAINNET`.
@@ -78,5 +79,5 @@ All write-capable methods return `SdkError::MissingRunner` until a `ContractRunn
 - Transfer/pathfinding helpers default to wrapped balances; tune `AdvancedTransferOptions` when you need exclusions or simulated balances/trust edges.
 - Avatar wrappers expose `total_balance`, aggregated trust helpers, `plan_direct_transfer` / `direct_transfer`, and `plan_replenish` / `replenish`; human and organisation avatars also expose `max_replenishable` plus `plan_replenish_max` / `replenish_max`.
 - The SDK still uses flatter Rust methods instead of the TS object namespaces (`balances.*`, `trust.*`, `groupToken.*`), so some convenience parity remains outstanding even where the underlying capability now exists.
-- The main remaining facade gaps are fuller group-token redeem/member convenience and the richer TS invitation surface.
+- The main remaining facade gaps are the richer TS invitation surface and wallet-backend execution parity.
 - Generate local rustdoc with `cargo doc -p circles-sdk --all-features`.

--- a/crates/sdk/src/avatar/common.rs
+++ b/crates/sdk/src/avatar/common.rs
@@ -351,6 +351,36 @@ impl CommonAvatar {
         self.send(txs).await
     }
 
+    /// Plan a TS-style automatic group-token redeem flow for `group`.
+    pub async fn plan_group_token_redeem(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        let builder = TransferBuilder::new(self.core.config.clone())?;
+        let txs = builder
+            .construct_group_token_redeem(self.address, group, amount)
+            .await?;
+        Ok(txs
+            .into_iter()
+            .map(|tx| PreparedTransaction {
+                to: tx.to,
+                data: tx.data,
+                value: Some(tx.value),
+            })
+            .collect())
+    }
+
+    /// Execute a group-token redeem flow using the runner (if present).
+    pub async fn group_token_redeem(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<crate::SubmittedTx>, SdkError> {
+        let txs = self.plan_group_token_redeem(group, amount).await?;
+        self.send(txs).await
+    }
+
     /// Find a path between this avatar and `to` with a target flow (defaults use_wrapped_balances=true).
     pub async fn find_path(
         &self,

--- a/crates/sdk/src/avatar/human.rs
+++ b/crates/sdk/src/avatar/human.rs
@@ -374,6 +374,24 @@ impl HumanAvatar {
         self.common.send(txs).await
     }
 
+    /// Plan a group-token redeem flow back into trusted treasury collateral.
+    pub async fn plan_group_token_redeem(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        self.common.plan_group_token_redeem(group, amount).await
+    }
+
+    /// Execute a group-token redeem flow back into trusted treasury collateral.
+    pub async fn redeem_group_token(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.common.group_token_redeem(group, amount).await
+    }
+
     /// Compute the maximum amount mintable for a group from this avatar.
     pub async fn max_group_token_mintable(&self, group: Address) -> Result<U256, SdkError> {
         let mint_handler = self

--- a/crates/sdk/src/avatar/organisation.rs
+++ b/crates/sdk/src/avatar/organisation.rs
@@ -317,6 +317,24 @@ impl OrganisationAvatar {
         self.common.send(txs).await
     }
 
+    /// Plan a group-token redeem flow back into trusted treasury collateral.
+    pub async fn plan_group_token_redeem(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<PreparedTransaction>, SdkError> {
+        self.common.plan_group_token_redeem(group, amount).await
+    }
+
+    /// Execute a group-token redeem flow back into trusted treasury collateral.
+    pub async fn redeem_group_token(
+        &self,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<SubmittedTx>, SdkError> {
+        self.common.group_token_redeem(group, amount).await
+    }
+
     /// Compute the maximum amount mintable for a group from this avatar.
     pub async fn max_group_token_mintable(&self, group: Address) -> Result<U256, SdkError> {
         let mint_handler = self

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -47,6 +47,8 @@
 //!   [`BaseGroupAvatar::plan_transfer`] for pathfinding-based transaction planning.
 //! - [`HumanAvatar::plan_direct_transfer`], [`OrganisationAvatar::plan_direct_transfer`], and
 //!   [`BaseGroupAvatar::plan_direct_transfer`] for TS-style direct-send planning.
+//! - [`HumanAvatar::plan_group_token_redeem`] and
+//!   [`OrganisationAvatar::plan_group_token_redeem`] for automatic group-token redeem planning.
 //!
 //! ## Validation
 //!
@@ -69,14 +71,14 @@ use alloy_json_rpc::RpcSend;
 use alloy_primitives::Address;
 pub use avatar::{BaseGroupAvatar, HumanAvatar, OrganisationAvatar};
 use circles_profiles::{Profile, Profiles};
-use circles_rpc::CirclesRpc;
 #[cfg(feature = "ws")]
 use circles_rpc::events::subscription::CirclesSubscription;
+use circles_rpc::{CirclesRpc, PagedQuery};
 #[cfg(feature = "ws")]
 use circles_types::CirclesEvent;
 use circles_types::{
-    AggregatedTrustRelation, AvatarInfo, AvatarType, CirclesConfig, TokenBalanceResponse,
-    TrustRelation,
+    AggregatedTrustRelation, AvatarInfo, AvatarType, CirclesConfig, GroupMembershipRow,
+    GroupTokenHolderRow, SortOrder, TokenBalanceResponse, TrustRelation,
 };
 use core::Core;
 pub use runner::{ContractRunner, PreparedTransaction, RunnerError, SubmittedTx, call_to_tx};
@@ -235,6 +237,40 @@ impl Sdk {
             .token()
             .get_token_balances(avatar, as_time_circles, use_v2)
             .await?)
+    }
+
+    /// Get all members of a specific group via the shared paged query helper.
+    pub fn group_members(
+        &self,
+        group: Address,
+        limit: u32,
+        sort_order: SortOrder,
+    ) -> PagedQuery<GroupMembershipRow> {
+        self.rpc.group().get_group_members(group, limit, sort_order)
+    }
+
+    /// Get collateral balances held in a group's treasury.
+    pub async fn group_collateral(
+        &self,
+        group: Address,
+    ) -> Result<Vec<TokenBalanceResponse>, SdkError> {
+        let treasury = self
+            .core
+            .base_group(group)
+            .BASE_TREASURY()
+            .call()
+            .await
+            .map_err(|e| SdkError::Contract(e.to_string()))?;
+        Ok(self
+            .rpc
+            .token()
+            .get_token_balances(treasury, false, true)
+            .await?)
+    }
+
+    /// Get holders of a group token ordered like the TypeScript helper.
+    pub fn group_holders(&self, group: Address, limit: u32) -> PagedQuery<GroupTokenHolderRow> {
+        self.rpc.group().get_group_holders(group, limit)
     }
 
     /// Convenience accessor for avatar info (read-only).

--- a/crates/transfers/README.md
+++ b/crates/transfers/README.md
@@ -8,6 +8,7 @@ Builder for Circles transfer transactions (port of TS `@aboutcircles/sdk-transfe
 - Self-transfer fast-path resolves wrapper type via LiftERC20; approval inclusion is configurable.
 - Includes an aggregate-capable entrypoint that mirrors the TS recipient self-transfer behavior when `to_tokens` selects exactly one token.
 - Includes the TS-style replenish planner: use existing unwrapped balance first, then local unwraps, then deficit pathfinding with temporary trust when needed.
+- Includes the TS-style automatic group-token redeem planner: inspect treasury collateral, filter by trusted ERC-1155 tokens, validate max redeemable flow, then build the redeem flow matrix.
 - Fixtures cover demurraged-only, mixed wrappers (with rewrap), and a no-leftover inflationary case (static balance forced to zero for now).
 
 ## Usage

--- a/crates/transfers/src/builder.rs
+++ b/crates/transfers/src/builder.rs
@@ -1,15 +1,16 @@
 use crate::error::{TransferError, TransfersErrorSource};
 use alloy_primitives::{aliases::U96, Address, Bytes, U256};
 use alloy_sol_types::SolCall;
-use circles_abis::{DemurrageCircles, HubV2, InflationaryCircles, LiftERC20};
+use circles_abis::{BaseGroup, DemurrageCircles, HubV2, InflationaryCircles, LiftERC20};
 use circles_pathfinder::{
     create_flow_matrix, expected_unwrapped_totals, replace_wrapped_tokens,
     token_info_map_from_path, wrapped_totals_from_path,
 };
 use circles_rpc::CirclesRpc;
 use circles_types::{
-    AdvancedTransferOptions, Balance, CirclesConfig, FindPathParams, PathfindingTransferStep,
-    SimulatedTrust, TokenBalanceResponse, TokenInfo, TransferStep,
+    AdvancedTransferOptions, AggregatedTrustRelation, Balance, CirclesConfig, FindPathParams,
+    PathfindingTransferStep, SimulatedTrust, TokenBalanceResponse, TokenInfo, TransferStep,
+    TrustRelationType,
 };
 use circles_utils::converter::{
     atto_circles_to_atto_static_circles, atto_static_circles_to_atto_circles,
@@ -358,6 +359,155 @@ impl TransferBuilder {
 
         if needs_temporary_trust {
             transactions.push(self.trust_tx(token_id, U96::ZERO));
+        }
+
+        Ok(transactions)
+    }
+
+    /// Construct the TS-style automatic group-token redeem flow.
+    pub async fn construct_group_token_redeem(
+        &self,
+        from: Address,
+        group: Address,
+        amount: U256,
+    ) -> Result<Vec<TransferTx>, TransferError> {
+        if amount.is_zero() {
+            return Err(TransferError::generic(
+                "group token redeem amount must be positive",
+                Some("GROUP_TOKEN_REDEEM_INVALID_AMOUNT"),
+                TransfersErrorSource::Validation,
+            ));
+        }
+
+        let group_info = self
+            .rpc
+            .token_info()
+            .get_token_info(group)
+            .await
+            .map_err(|e| {
+                TransferError::generic(
+                    e.to_string(),
+                    None::<String>,
+                    TransfersErrorSource::Transfers,
+                )
+            })?;
+
+        if group_info.token_type != "CrcV2_RegisterGroup" {
+            return Err(TransferError::generic(
+                format!(
+                    "Only base groups can be redeemed through group-token convenience; got token type {} for {group:#x}.",
+                    group_info.token_type
+                ),
+                Some("GROUP_TOKEN_REDEEM_UNSUPPORTED_TYPE"),
+                TransfersErrorSource::Validation,
+            ));
+        }
+
+        let treasury = self.group_treasury(group).await?;
+        let treasury_balances = self
+            .rpc
+            .token()
+            .get_token_balances(treasury, false, true)
+            .await
+            .map_err(|e| {
+                TransferError::generic(
+                    e.to_string(),
+                    None::<String>,
+                    TransfersErrorSource::Transfers,
+                )
+            })?;
+        let treasury_tokens = treasury_balances
+            .into_iter()
+            .filter(|balance| balance.is_erc1155)
+            .map(|balance| balance.token_address)
+            .collect::<HashSet<_>>();
+
+        let trust_relationships = self
+            .rpc
+            .trust()
+            .get_aggregated_trust_relations(from)
+            .await
+            .map_err(|e| {
+                TransferError::generic(
+                    e.to_string(),
+                    None::<String>,
+                    TransfersErrorSource::Transfers,
+                )
+            })?;
+        let expected_to_tokens =
+            filter_redeemable_collateral_tokens(&trust_relationships, &treasury_tokens);
+
+        if expected_to_tokens.is_empty() {
+            return Err(TransferError::generic(
+                format!(
+                    "No trusted ERC-1155 collateral tokens are available in treasury {treasury:#x} for group {group:#x}."
+                ),
+                Some("GROUP_TOKEN_REDEEM_NO_TRUSTED_COLLATERAL"),
+                TransfersErrorSource::Validation,
+            ));
+        }
+
+        let max_redeemable = self
+            .rpc
+            .pathfinder()
+            .find_path(FindPathParams {
+                from,
+                to: from,
+                target_flow: U256::MAX,
+                use_wrapped_balances: Some(false),
+                from_tokens: Some(vec![group]),
+                to_tokens: Some(expected_to_tokens.clone()),
+                exclude_from_tokens: None,
+                exclude_to_tokens: None,
+                simulated_balances: None,
+                simulated_trusts: None,
+                max_transfers: None,
+            })
+            .await
+            .map_err(|e| {
+                TransferError::generic(
+                    format!("Failed to compute max redeemable group flow: {e}"),
+                    Some("GROUP_TOKEN_REDEEM_MAX_FLOW_FAILED"),
+                    TransfersErrorSource::Pathfinding,
+                )
+            })?;
+
+        if max_redeemable.max_flow < amount {
+            return Err(TransferError::generic(
+                format!(
+                    "Specified amount {amount} exceeds max redeemable flow {} for group {group:#x}.",
+                    max_redeemable.max_flow
+                ),
+                Some("GROUP_TOKEN_REDEEM_EXCEEDS_MAX_FLOW"),
+                TransfersErrorSource::Validation,
+            ));
+        }
+
+        let transactions = self
+            .construct_advanced_transfer(
+                from,
+                from,
+                amount,
+                Some(AdvancedTransferOptions {
+                    use_wrapped_balances: Some(false),
+                    from_tokens: Some(vec![group]),
+                    to_tokens: Some(expected_to_tokens),
+                    exclude_from_tokens: None,
+                    exclude_to_tokens: None,
+                    simulated_balances: None,
+                    simulated_trusts: None,
+                    max_transfers: None,
+                    tx_data: None,
+                }),
+            )
+            .await?;
+
+        if transactions.is_empty() {
+            return Err(TransferError::generic(
+                "No transactions generated for group token redeem.",
+                Some("GROUP_TOKEN_REDEEM_EMPTY"),
+                TransfersErrorSource::Transfers,
+            ));
         }
 
         Ok(transactions)
@@ -785,6 +935,28 @@ fn replenish_trust_expiry() -> U96 {
     U96::from(expiry)
 }
 
+fn filter_redeemable_collateral_tokens(
+    trust_relationships: &[AggregatedTrustRelation],
+    treasury_tokens: &HashSet<Address>,
+) -> Vec<Address> {
+    let mut tokens = Vec::new();
+
+    for trust in trust_relationships {
+        let trusted = matches!(
+            trust.relation,
+            TrustRelationType::Trusts | TrustRelationType::MutuallyTrusts
+        );
+        if trusted
+            && treasury_tokens.contains(&trust.object_avatar)
+            && !tokens.contains(&trust.object_avatar)
+        {
+            tokens.push(trust.object_avatar);
+        }
+    }
+
+    tokens
+}
+
 impl TransferBuilder {
     async fn needs_approval(&self, operator: Address) -> Option<bool> {
         let Ok(url) = self.config.circles_rpc_url.parse() else {
@@ -857,6 +1029,25 @@ impl TransferBuilder {
             }));
         }
         Ok(None)
+    }
+
+    async fn group_treasury(&self, group: Address) -> Result<Address, TransferError> {
+        let url = self.config.circles_rpc_url.parse().map_err(|e| {
+            TransferError::generic(
+                format!("Invalid RPC URL for group treasury lookup: {e}"),
+                Some("GROUP_TOKEN_REDEEM_INVALID_RPC_URL"),
+                TransfersErrorSource::Transfers,
+            )
+        })?;
+        let provider = alloy_provider::ProviderBuilder::new().connect_http(url);
+        let base_group = BaseGroup::new(group, provider);
+        base_group.BASE_TREASURY().call().await.map_err(|e| {
+            TransferError::generic(
+                e.to_string(),
+                Some("GROUP_TOKEN_REDEEM_TREASURY_LOOKUP_FAILED"),
+                TransfersErrorSource::Transfers,
+            )
+        })
     }
 
     async fn is_trusted(&self, truster: Address, trustee: Address) -> Result<bool, TransferError> {
@@ -1075,24 +1266,60 @@ mod tests {
 
         let balances = vec![
             TokenBalanceResponse {
+                token_address: token_owner,
                 token_id: token_owner,
                 balance: Balance::Raw(U256::from(10u64)),
                 static_atto_circles: None,
                 static_circles: None,
+                token_type: None,
+                version: None,
+                atto_circles: None,
+                circles: None,
+                atto_crc: None,
+                crc: None,
+                is_erc20: false,
+                is_erc1155: true,
+                is_wrapped: false,
+                is_inflationary: false,
+                is_group: false,
                 token_owner,
             },
             TokenBalanceResponse {
+                token_address: dem_wrapper,
                 token_id: dem_wrapper,
                 balance: Balance::Raw(U256::from(20u64)),
                 static_atto_circles: Some(U256::from(20u64)),
                 static_circles: None,
+                token_type: None,
+                version: None,
+                atto_circles: None,
+                circles: None,
+                atto_crc: None,
+                crc: None,
+                is_erc20: true,
+                is_erc1155: false,
+                is_wrapped: true,
+                is_inflationary: false,
+                is_group: false,
                 token_owner,
             },
             TokenBalanceResponse {
+                token_address: inf_wrapper,
                 token_id: inf_wrapper,
                 balance: Balance::Raw(U256::from(30u64)),
                 static_atto_circles: Some(U256::from(40u64)),
                 static_circles: None,
+                token_type: None,
+                version: None,
+                atto_circles: None,
+                circles: None,
+                atto_crc: None,
+                crc: None,
+                is_erc20: true,
+                is_erc1155: false,
+                is_wrapped: true,
+                is_inflationary: true,
+                is_group: false,
                 token_owner,
             },
         ];

--- a/crates/transfers/tests/replenish_builder_tests.rs
+++ b/crates/transfers/tests/replenish_builder_tests.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{address, Address, Bytes, U256};
 use alloy_sol_types::SolCall;
-use circles_abis::HubV2;
-use circles_transfers::TransferBuilder;
+use circles_abis::{BaseGroup, HubV2};
+use circles_transfers::{TransferBuilder, TransferError};
 use circles_types::CirclesConfig;
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -185,6 +185,12 @@ fn u256_result(value: U256) -> Value {
         .for_each(|(idx, byte)| {
             encoded[idx] = *byte;
         });
+    json!(format!("0x{}", hex_bytes(&encoded)))
+}
+
+fn address_result(value: Address) -> Value {
+    let mut encoded = [0u8; 32];
+    encoded[12..].copy_from_slice(value.as_slice());
     json!(format!("0x{}", hex_bytes(&encoded)))
 }
 
@@ -515,4 +521,233 @@ async fn construct_replenish_handles_wrapped_path_branch() {
         .find(|request| request["method"].as_str() == Some("circlesV2_findPath"))
         .expect("path request");
     assert_eq!(path_request["params"][0]["SimulatedTrusts"], Value::Null);
+}
+
+#[tokio::test]
+async fn construct_group_token_redeem_matches_ts_flow_shape() {
+    let from = address!("0xde374ece6fa50e781e81aac78e811b33d16912c7");
+    let group = address!("0x1111111111111111111111111111111111111111");
+    let treasury = address!("0x2222222222222222222222222222222222222222");
+    let collateral_a = address!("0x3333333333333333333333333333333333333333");
+    let collateral_b = address!("0x4444444444444444444444444444444444444444");
+    let amount = U256::from(100u64);
+    let treasury_selector = selector_hex(BaseGroup::BASE_TREASURYCall {});
+
+    let server = MockRpcServer::spawn(move |request| match request["method"].as_str().unwrap() {
+        "circles_getTokenInfo" => json_rpc_success(
+            &request["id"],
+            json!({
+                "block_number": 0,
+                "timestamp": 0,
+                "transaction_index": 0,
+                "log_index": 0,
+                "transaction_hash": format!("{:#x}", alloy_primitives::TxHash::ZERO),
+                "version": 2,
+                "info_type": null,
+                "token_type": "CrcV2_RegisterGroup",
+                "token": format!("{group:#x}"),
+                "token_owner": format!("{group:#x}"),
+            }),
+        ),
+        "circlesV2_getTokenBalances" => json_rpc_success(
+            &request["id"],
+            json!([
+                {
+                    "tokenAddress": format!("{collateral_a:#x}"),
+                    "tokenId": format!("{collateral_a:#x}"),
+                    "tokenOwner": format!("{collateral_a:#x}"),
+                    "tokenType": "CrcV2_RegisterHuman",
+                    "version": 2,
+                    "attoCircles": "1000",
+                    "circles": 0.000000000000001,
+                    "staticAttoCircles": "1000",
+                    "staticCircles": 0.000000000000001,
+                    "attoCrc": "1000",
+                    "crc": 0.000000000000001,
+                    "isErc20": false,
+                    "isErc1155": true,
+                    "isWrapped": false,
+                    "isInflationary": false,
+                    "isGroup": false
+                },
+                {
+                    "tokenAddress": format!("{collateral_b:#x}"),
+                    "tokenId": format!("{collateral_b:#x}"),
+                    "tokenOwner": format!("{collateral_b:#x}"),
+                    "tokenType": "CrcV2_RegisterHuman",
+                    "version": 2,
+                    "attoCircles": "1000",
+                    "circles": 0.000000000000001,
+                    "staticAttoCircles": "1000",
+                    "staticCircles": 0.000000000000001,
+                    "attoCrc": "1000",
+                    "crc": 0.000000000000001,
+                    "isErc20": false,
+                    "isErc1155": true,
+                    "isWrapped": false,
+                    "isInflationary": false,
+                    "isGroup": false
+                }
+            ]),
+        ),
+        "circles_getAggregatedTrustRelations" => json_rpc_success(
+            &request["id"],
+            json!([
+                {
+                    "subject_avatar": format!("{from:#x}"),
+                    "relation": "trusts",
+                    "object_avatar": format!("{collateral_a:#x}"),
+                    "timestamp": 0
+                },
+                {
+                    "subject_avatar": format!("{from:#x}"),
+                    "relation": "mutuallyTrusts",
+                    "object_avatar": format!("{collateral_b:#x}"),
+                    "timestamp": 0
+                }
+            ]),
+        ),
+        "circlesV2_findPath" => json_rpc_success(
+            &request["id"],
+            json!({
+                "maxFlow": amount,
+                "transfers": [{
+                    "from": format!("{from:#x}"),
+                    "to": format!("{from:#x}"),
+                    "tokenOwner": format!("{collateral_a:#x}"),
+                    "value": amount,
+                }]
+            }),
+        ),
+        "circles_getTokenInfoBatch" => json_rpc_success(
+            &request["id"],
+            json!([{
+                "block_number": 0,
+                "timestamp": 0,
+                "transaction_index": 0,
+                "log_index": 0,
+                "transaction_hash": format!("{:#x}", alloy_primitives::TxHash::ZERO),
+                "version": 2,
+                "info_type": null,
+                "token_type": "CrcV2_RegisterHuman",
+                "token": format!("{collateral_a:#x}"),
+                "token_owner": format!("{collateral_a:#x}"),
+            }]),
+        ),
+        "eth_call" => {
+            let data = eth_call_data(request);
+            assert!(data.starts_with(&treasury_selector));
+            json_rpc_success(&request["id"], address_result(treasury))
+        }
+        other => panic!("unexpected method {other}"),
+    });
+
+    let builder = TransferBuilder::new(demo_config(server.url()))
+        .expect("builder")
+        .with_approval_check(false);
+    let txs = builder
+        .construct_group_token_redeem(from, group, amount)
+        .await
+        .expect("construct group token redeem");
+
+    assert_eq!(txs.len(), 2);
+    assert_eq!(txs[0].to, demo_config(server.url()).v2_hub_address);
+    assert_eq!(txs[1].to, demo_config(server.url()).v2_hub_address);
+    assert_eq!(
+        recorded_method_count(&server.requests(), "circlesV2_findPath"),
+        2
+    );
+
+    let first_path_request = server
+        .requests()
+        .into_iter()
+        .find(|request| request["method"].as_str() == Some("circlesV2_findPath"))
+        .expect("first path request");
+    assert_eq!(
+        first_path_request["params"][0]["UseWrappedBalances"],
+        json!(false)
+    );
+    assert_eq!(
+        first_path_request["params"][0]["FromTokens"],
+        json!([format!("{group:#x}")])
+    );
+    assert_eq!(
+        first_path_request["params"][0]["ToTokens"],
+        json!([format!("{collateral_a:#x}"), format!("{collateral_b:#x}")])
+    );
+}
+
+#[tokio::test]
+async fn construct_group_token_redeem_fails_without_trusted_collateral() {
+    let from = address!("0xde374ece6fa50e781e81aac78e811b33d16912c7");
+    let group = address!("0x1111111111111111111111111111111111111111");
+    let treasury = address!("0x2222222222222222222222222222222222222222");
+    let collateral = address!("0x3333333333333333333333333333333333333333");
+    let treasury_selector = selector_hex(BaseGroup::BASE_TREASURYCall {});
+
+    let server = MockRpcServer::spawn(move |request| match request["method"].as_str().unwrap() {
+        "circles_getTokenInfo" => json_rpc_success(
+            &request["id"],
+            json!({
+                "block_number": 0,
+                "timestamp": 0,
+                "transaction_index": 0,
+                "log_index": 0,
+                "transaction_hash": format!("{:#x}", alloy_primitives::TxHash::ZERO),
+                "version": 2,
+                "info_type": null,
+                "token_type": "CrcV2_RegisterGroup",
+                "token": format!("{group:#x}"),
+                "token_owner": format!("{group:#x}"),
+            }),
+        ),
+        "circlesV2_getTokenBalances" => json_rpc_success(
+            &request["id"],
+            json!([{
+                "tokenAddress": format!("{collateral:#x}"),
+                "tokenId": format!("{collateral:#x}"),
+                "tokenOwner": format!("{collateral:#x}"),
+                "tokenType": "CrcV2_RegisterHuman",
+                "version": 2,
+                "attoCircles": "1000",
+                "circles": 0.000000000000001,
+                "staticAttoCircles": "1000",
+                "staticCircles": 0.000000000000001,
+                "attoCrc": "1000",
+                "crc": 0.000000000000001,
+                "isErc20": false,
+                "isErc1155": true,
+                "isWrapped": false,
+                "isInflationary": false,
+                "isGroup": false
+            }]),
+        ),
+        "circles_getAggregatedTrustRelations" => json_rpc_success(&request["id"], json!([])),
+        "eth_call" => {
+            let data = eth_call_data(request);
+            assert!(data.starts_with(&treasury_selector));
+            json_rpc_success(&request["id"], address_result(treasury))
+        }
+        other => panic!("unexpected method {other}"),
+    });
+
+    let builder = TransferBuilder::new(demo_config(server.url())).expect("builder");
+    let err = builder
+        .construct_group_token_redeem(from, group, U256::from(10u64))
+        .await
+        .expect_err("missing trusted collateral should fail");
+
+    match err {
+        TransferError::Generic { code, .. } => {
+            assert_eq!(
+                code.as_deref(),
+                Some("GROUP_TOKEN_REDEEM_NO_TRUSTED_COLLATERAL")
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    assert_eq!(
+        recorded_method_count(&server.requests(), "circlesV2_findPath"),
+        0
+    );
 }

--- a/crates/types/src/group.rs
+++ b/crates/types/src/group.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{Address, TxHash, U256};
 use serde::{Deserialize, Serialize};
 
 /// Group row information
@@ -37,6 +37,17 @@ pub struct GroupMembershipRow {
     pub group: Address,
     pub member: Address,
     pub expiry_time: u64,
+}
+
+/// Group token holder row for `GroupTokenHoldersBalance`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupTokenHolderRow {
+    pub group: Address,
+    pub holder: Address,
+    pub total_balance: U256,
+    pub demurraged_total_balance: U256,
+    pub fraction_ownership: f64,
 }
 
 /// Group query parameters

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -176,7 +176,7 @@ mod events;
 pub use events::{CirclesBaseEvent, CirclesEvent, CirclesEventType, RpcSubscriptionEvent};
 
 mod group;
-pub use group::{GroupMembershipRow, GroupQueryParams, GroupRow};
+pub use group::{GroupMembershipRow, GroupQueryParams, GroupRow, GroupTokenHolderRow};
 
 mod network;
 pub use network::{EventType, NetworkSnapshot};
@@ -204,8 +204,9 @@ pub use rpc::{
 
 mod query;
 pub use query::{
-    ColumnInfo, Conjunction, ConjunctionType, Cursor, EventRow, Filter, FilterPredicate,
-    FilterType, OrderBy, PagedQueryParams, PagedResult, QueryParams, SortOrder, TableInfo,
+    ColumnInfo, Conjunction, ConjunctionType, Cursor, CursorColumn, EventRow, Filter,
+    FilterPredicate, FilterType, OrderBy, PagedQueryParams, PagedResult, QueryParams, SortOrder,
+    TableInfo,
 };
 
 mod pathfinding;

--- a/crates/types/src/query.rs
+++ b/crates/types/src/query.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Filter types for query predicates.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -124,7 +125,7 @@ pub enum SortOrder {
 }
 
 /// Order by clause.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OrderBy {
     #[serde(rename = "Column")]
     pub column: String,
@@ -143,6 +144,27 @@ impl OrderBy {
 
     pub fn desc(column: String) -> Self {
         Self::new(column, SortOrder::DESC)
+    }
+}
+
+/// Cursor column configuration for flexible paged queries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorColumn {
+    pub name: String,
+    pub sort_order: SortOrder,
+}
+
+impl CursorColumn {
+    pub fn new(name: String, sort_order: SortOrder) -> Self {
+        Self { name, sort_order }
+    }
+
+    pub fn asc(name: String) -> Self {
+        Self::new(name, SortOrder::ASC)
+    }
+
+    pub fn desc(name: String) -> Self {
+        Self::new(name, SortOrder::DESC)
     }
 }
 
@@ -224,7 +246,26 @@ pub struct EventRow {
 
 /// A cursor is a sortable unique identifier for a specific log entry.
 /// Used to paginate through query results efficiently.
-pub type Cursor = EventRow;
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Cursor {
+    pub block_number: u64,
+    pub transaction_index: u32,
+    pub log_index: u32,
+    pub batch_index: Option<u32>,
+    pub timestamp: Option<u64>,
+    #[serde(default)]
+    pub values: BTreeMap<String, serde_json::Value>,
+}
+
+impl Cursor {
+    pub fn value(&self, column: &str) -> Option<&serde_json::Value> {
+        self.values.get(column)
+    }
+
+    pub fn insert_value(&mut self, column: String, value: serde_json::Value) {
+        self.values.insert(column, value);
+    }
+}
 
 /// Result of a paginated query
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,6 +328,12 @@ pub struct PagedQueryParams {
     /// The filters to apply to the query
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<Vec<Filter>>,
+    /// Custom cursor columns for non-event tables.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_columns: Option<Vec<CursorColumn>>,
+    /// Explicit order columns when they differ from the cursor columns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_columns: Option<Vec<OrderBy>>,
     /// The number of results to return per page
     pub limit: u32,
 }
@@ -305,6 +352,8 @@ impl PagedQueryParams {
             sort_order,
             columns,
             filter: None,
+            cursor_columns: None,
+            order_columns: None,
             limit,
         }
     }
@@ -312,5 +361,49 @@ impl PagedQueryParams {
     pub fn with_filter(mut self, filter: Vec<Filter>) -> Self {
         self.filter = Some(filter);
         self
+    }
+
+    pub fn with_cursor_columns(mut self, cursor_columns: Vec<CursorColumn>) -> Self {
+        self.cursor_columns = Some(cursor_columns);
+        self
+    }
+
+    pub fn with_order_columns(mut self, order_columns: Vec<OrderBy>) -> Self {
+        self.order_columns = Some(order_columns);
+        self
+    }
+
+    pub fn resolved_cursor_columns(&self) -> Vec<CursorColumn> {
+        if let Some(cursor_columns) = &self.cursor_columns {
+            if !cursor_columns.is_empty() {
+                return cursor_columns.clone();
+            }
+        }
+
+        let mut columns = vec![
+            CursorColumn::new("blockNumber".to_string(), self.sort_order.clone()),
+            CursorColumn::new("transactionIndex".to_string(), self.sort_order.clone()),
+            CursorColumn::new("logIndex".to_string(), self.sort_order.clone()),
+        ];
+        if self.table == "TransferBatch" {
+            columns.push(CursorColumn::new(
+                "batchIndex".to_string(),
+                self.sort_order.clone(),
+            ));
+        }
+        columns
+    }
+
+    pub fn resolved_order_columns(&self) -> Vec<OrderBy> {
+        if let Some(order_columns) = &self.order_columns {
+            if !order_columns.is_empty() {
+                return order_columns.clone();
+            }
+        }
+
+        self.resolved_cursor_columns()
+            .into_iter()
+            .map(|column| OrderBy::new(column.name, column.sort_order))
+            .collect()
     }
 }

--- a/crates/types/src/rpc.rs
+++ b/crates/types/src/rpc.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, TxHash, U256};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// JSON-RPC request structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -128,8 +128,10 @@ pub enum Balance {
 }
 
 /// Token balance response from circles_getTokenBalances
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TokenBalanceResponse {
+    #[serde(rename = "tokenAddress")]
+    pub token_address: Address,
     #[serde(rename = "tokenId")]
     pub token_id: Address,
     pub balance: Balance,
@@ -138,7 +140,106 @@ pub struct TokenBalanceResponse {
     pub static_atto_circles: Option<U256>,
     #[serde(default, rename = "staticCircles")]
     pub static_circles: Option<f64>,
+    #[serde(default, rename = "tokenType", skip_serializing_if = "Option::is_none")]
+    pub token_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u32>,
+    #[serde(
+        default,
+        rename = "attoCircles",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub atto_circles: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub circles: Option<f64>,
+    #[serde(default, rename = "attoCrc", skip_serializing_if = "Option::is_none")]
+    pub atto_crc: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crc: Option<f64>,
+    #[serde(default, rename = "isErc20")]
+    pub is_erc20: bool,
+    #[serde(default, rename = "isErc1155")]
+    pub is_erc1155: bool,
+    #[serde(default, rename = "isWrapped")]
+    pub is_wrapped: bool,
+    #[serde(default, rename = "isInflationary")]
+    pub is_inflationary: bool,
+    #[serde(default, rename = "isGroup")]
+    pub is_group: bool,
+    #[serde(rename = "tokenOwner")]
     pub token_owner: Address,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TokenBalanceResponseWire {
+    #[serde(default, rename = "tokenAddress", alias = "token_address")]
+    token_address: Option<Address>,
+    #[serde(rename = "tokenId", alias = "token_id")]
+    token_id: Address,
+    #[serde(default)]
+    balance: Option<Balance>,
+    #[serde(default, rename = "staticAttoCircles")]
+    static_atto_circles: Option<U256>,
+    #[serde(default, rename = "staticCircles")]
+    static_circles: Option<f64>,
+    #[serde(default, rename = "tokenType", alias = "token_type")]
+    token_type: Option<String>,
+    #[serde(default)]
+    version: Option<u32>,
+    #[serde(default, rename = "attoCircles")]
+    atto_circles: Option<U256>,
+    #[serde(default)]
+    circles: Option<f64>,
+    #[serde(default, rename = "attoCrc")]
+    atto_crc: Option<U256>,
+    #[serde(default)]
+    crc: Option<f64>,
+    #[serde(default, rename = "isErc20", alias = "is_erc20")]
+    is_erc20: bool,
+    #[serde(default, rename = "isErc1155", alias = "is_erc1155")]
+    is_erc1155: bool,
+    #[serde(default, rename = "isWrapped", alias = "is_wrapped")]
+    is_wrapped: bool,
+    #[serde(default, rename = "isInflationary", alias = "is_inflationary")]
+    is_inflationary: bool,
+    #[serde(default, rename = "isGroup", alias = "is_group")]
+    is_group: bool,
+    #[serde(rename = "tokenOwner", alias = "token_owner")]
+    token_owner: Address,
+}
+
+impl<'de> Deserialize<'de> for TokenBalanceResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = TokenBalanceResponseWire::deserialize(deserializer)?;
+        let balance = wire
+            .balance
+            .or_else(|| wire.atto_circles.map(Balance::Raw))
+            .or_else(|| wire.circles.map(Balance::TimeCircles))
+            .ok_or_else(|| serde::de::Error::missing_field("balance / attoCircles / circles"))?;
+
+        Ok(Self {
+            token_address: wire.token_address.unwrap_or(wire.token_id),
+            token_id: wire.token_id,
+            balance,
+            static_atto_circles: wire.static_atto_circles,
+            static_circles: wire.static_circles,
+            token_type: wire.token_type,
+            version: wire.version,
+            atto_circles: wire.atto_circles,
+            circles: wire.circles,
+            atto_crc: wire.atto_crc,
+            crc: wire.crc,
+            is_erc20: wire.is_erc20,
+            is_erc1155: wire.is_erc1155,
+            is_wrapped: wire.is_wrapped,
+            is_inflationary: wire.is_inflationary,
+            is_group: wire.is_group,
+            token_owner: wire.token_owner,
+        })
+    }
 }
 
 /// Transaction history row matching the TS RPC helper shape.


### PR DESCRIPTION
## Summary
- add TS-style group-token redeem planning support across transfers and sdk
- add flexible paged query cursor/order support and expose group holder helpers
- refresh the parity snapshot after closing ExecPlan 021

## Validation
- cargo check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test