### PR TITLE
chore: prepare crate release and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish Crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate and print the publish plan instead of pushing to crates.io"
+        required: true
+        default: true
+        type: boolean
+      start_at:
+        description: "Crate to start from when resuming a release"
+        required: true
+        default: "circles-types"
+        type: choice
+        options:
+          - circles-types
+          - circles-utils
+          - circles-rpc
+          - circles-pathfinder
+          - circles-transfers
+          - circles-sdk
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Ensure stable Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Cache Cargo registry and target directory
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Validate workspace
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
+          cargo test
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          chmod +x scripts/publish-crates.sh
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            scripts/publish-crates.sh --dry-run --start-at "${{ inputs.start_at }}"
+          else
+            scripts/publish-crates.sh --publish --start-at "${{ inputs.start_at }}"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,22 @@ For detailed changes, see individual crate changelogs:
 - [circles-types](crates/types/CHANGELOG.md) - Core type definitions
 - [circles-pathfinder](crates/pathfinder/CHANGELOG.md) - Pathfinding and flow matrix calculation
 
-## [0.3.0] - 2025-12-05
+## [0.5.0] - 2026-03-26
 
 ### Coordinated Changes
+- **circles-types v0.3.1**: Expanded pathfinding/query/config/RPC types for invitation, referral, group, and pagination parity.
+- **circles-utils v0.1.1**: Refined converter math used by newer wrapper-aware flows.
+- **circles-rpc v0.1.1**: Added transaction history, group/member pagination, invitation helpers, and aggregated trust query surface.
+- **circles-pathfinder v0.5.1**: Added TS parity fixes for wrapped tokens, token info, netted flow checks, and richer RPC/path helpers.
+- **circles-transfers v0.1.1**: Added replenish parity, group-token redeem planning, aggregate helpers, and broader behavioral tests.
+- **circles-sdk v0.1.1**: Added direct transfer, group token, invite/referral, native wallet runner, runner-surface, and Safe execution-builder parity work.
+
+### Release Infrastructure
+- Added a repo-owned publish script and manual GitHub Actions publish workflow for ordered crates.io releases.
+
+### Documentation
+- Refreshed workspace and SDK parity snapshots for the current alpha state.
+
 ## [0.4.0] - 2025-12-05
 
 ### Coordinated Changes
@@ -28,6 +41,10 @@ For detailed changes, see individual crate changelogs:
 
 ### Documentation
 - Alpha docs and rustdoc polish across crates (wrapper guidance, WS notes, SDK usage).
+
+## [0.3.0] - 2025-07-17
+
+### Coordinated Changes
 
 ## [0.3.0] - 2025-07-17
 
@@ -111,7 +128,8 @@ When releasing breaking changes in `circles-types`:
 3. Test integration across workspace
 4. Publish dependent crates with appropriate version bumps
 
-[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/workspace-v0.4.0...HEAD
+[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/workspace-v0.5.0...HEAD
+[0.5.0]: https://github.com/deluXtreme/circles-rs/releases/tag/workspace-v0.5.0
 [0.4.0]: https://github.com/deluXtreme/circles-rs/releases/tag/workspace-v0.4.0
 [0.3.0]: https://github.com/deluXtreme/circles-rs/releases/tag/workspace-v0.3.0
 [0.2.1]: https://github.com/deluXtreme/circles-rs/releases/tag/workspace-v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "circles-pathfinder"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "circles-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "circles-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-contract",
  "alloy-json-rpc",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "circles-transfers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "circles-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "circles-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy-primitives",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ alloy-transport-http = "1.1.2"
 alloy-transport-ws = "1.1.2"
 async-trait = "0.1.89"
 circles-abis = { path = "crates/abis", version = "0.1.0" }
-circles-pathfinder = { path = "crates/pathfinder", version = "0.5.0" }
+circles-pathfinder = { path = "crates/pathfinder", version = "0.5.1" }
 circles-profiles = { path = "crates/profiles", version = "0.1.0" }
-circles-rpc = { path = "crates/rpc", version = "0.1.0" }
-circles-transfers = { path = "crates/transfers", version = "0.1.0" }
-circles-types = { path = "crates/types", version = "0.3.0" }
-circles-utils = { path = "crates/utils", version = "0.1.0" }
+circles-rpc = { path = "crates/rpc", version = "0.1.1" }
+circles-transfers = { path = "crates/transfers", version = "0.1.1" }
+circles-types = { path = "crates/types", version = "0.3.1" }
+circles-utils = { path = "crates/utils", version = "0.1.1" }
 futures = "0.3"
 reqwest = { version = "0.12.24", default-features = false, features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/pathfinder/CHANGELOG.md
+++ b/crates/pathfinder/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-03-26
+
+### Added
+- TS parity helpers for wrapped token rewriting, token info lookups, stream preparation, and explicit RPC entrypoints.
+
+### Changed
+- Aligned terminal-edge handling, fallback behavior, and netted-flow ordering with the TypeScript SDK.
+
+### Fixed
+- Added broader parity tests covering wrapped-token and malformed-path edge cases.
+
 ## [0.5.0] - 2025-07-18
 
 ### Added
@@ -147,5 +158,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error handling with `thiserror`
 - Modular architecture supporting both high-level and composable APIs
 
-[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/pathfinder-v0.1.0...HEAD
+[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/circles-pathfinder-v0.5.1...HEAD
+[0.5.1]: https://github.com/deluXtreme/circles-rs/releases/tag/circles-pathfinder-v0.5.1
 [0.1.0]: https://github.com/deluXtreme/circles-rs/releases/tag/pathfinder-v0.1.0

--- a/crates/pathfinder/Cargo.toml
+++ b/crates/pathfinder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-pathfinder"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["franco <0xpantera@proton.me>"]
 description = "Pathfinding and flow matrix calculation for the Circles protocol"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-rpc"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Circles JSON-RPC client (HTTP + WS)"
 license = "MIT OR Apache-2.0"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-sdk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Circles SDK orchestrating RPC, profiles, pathfinding, transfers, and contract runners."
 license = "MIT OR Apache-2.0"

--- a/crates/transfers/Cargo.toml
+++ b/crates/transfers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-transfers"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Transfer transaction builder for Circles protocol"
 authors = ["franco <0xpantera@proton.me>"]

--- a/crates/types/CHANGELOG.md
+++ b/crates/types/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-03-26
+
+### Added
+- Expanded Circles config, pathfinding, query, group, and RPC type coverage for the newer invitation/referral/group parity work.
+
+### Changed
+- Updated docs/examples to reflect the current workspace parity surface.
+
 ## [0.2.1] - 2025-06-10
 ### Documentation
 - Fixed changelog formatting and content for v0.2.0 release
@@ -34,5 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supports efficient serialization for JSON-RPC communication
 - Designed for zero-copy operations where possible
 
-[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/types-v0.1.0...HEAD
+[Unreleased]: https://github.com/deluXtreme/circles-rs/compare/circles-types-v0.3.1...HEAD
+[0.3.1]: https://github.com/deluXtreme/circles-rs/releases/tag/circles-types-v0.3.1
 [0.1.0]: https://github.com/deluXtreme/circles-rs/releases/tag/types-v0.1.0

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-types"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Core type definitions for the Circles protocol"
 repository = "https://github.com/deluXtreme/circles-rs"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circles-utils"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Shared Circles utilities (demurrage/inflation conversions, helpers)"
 license = "MIT OR Apache-2.0"

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODE="dry-run"
+START_AT="circles-types"
+
+CRATES=(
+  "circles-types"
+  "circles-utils"
+  "circles-rpc"
+  "circles-pathfinder"
+  "circles-transfers"
+  "circles-sdk"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/publish-crates.sh [--dry-run|--publish] [--start-at <crate>]
+
+Modes:
+  --dry-run   Print the publish order and versions (default)
+  --publish   Run `cargo publish` for each crate in publish order
+
+Options:
+  --start-at <crate>  Resume from the given crate name
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      MODE="dry-run"
+      shift
+      ;;
+    --publish)
+      MODE="publish"
+      shift
+      ;;
+    --start-at)
+      START_AT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+crate_manifest() {
+  case "$1" in
+    circles-types) echo "$ROOT_DIR/crates/types/Cargo.toml" ;;
+    circles-utils) echo "$ROOT_DIR/crates/utils/Cargo.toml" ;;
+    circles-rpc) echo "$ROOT_DIR/crates/rpc/Cargo.toml" ;;
+    circles-pathfinder) echo "$ROOT_DIR/crates/pathfinder/Cargo.toml" ;;
+    circles-transfers) echo "$ROOT_DIR/crates/transfers/Cargo.toml" ;;
+    circles-sdk) echo "$ROOT_DIR/crates/sdk/Cargo.toml" ;;
+    *)
+      echo "unknown crate: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+crate_version() {
+  awk -F '"' '/^version = / { print $2; exit }' "$(crate_manifest "$1")"
+}
+
+wait_for_crates_io() {
+  local crate="$1"
+  local version="$2"
+  local attempt
+
+  for attempt in $(seq 1 30); do
+    if curl -fsSL "https://crates.io/api/v1/crates/${crate}" | grep -q "\"num\":\"${version}\""; then
+      echo "crates.io index now exposes ${crate} ${version}"
+      return 0
+    fi
+    echo "waiting for crates.io to expose ${crate} ${version} (attempt ${attempt}/30)"
+    sleep 10
+  done
+
+  echo "timed out waiting for ${crate} ${version} to appear on crates.io" >&2
+  return 1
+}
+
+should_start=0
+for crate in "${CRATES[@]}"; do
+  if [[ "$crate" == "$START_AT" ]]; then
+    should_start=1
+  fi
+
+  if [[ $should_start -eq 0 ]]; then
+    continue
+  fi
+
+  version="$(crate_version "$crate")"
+  echo "==> ${MODE}: ${crate} ${version}"
+
+  if [[ "$MODE" == "dry-run" ]]; then
+    continue
+  else
+    cargo publish --locked -p "$crate" --manifest-path "$ROOT_DIR/Cargo.toml"
+    wait_for_crates_io "$crate" "$version"
+  fi
+done


### PR DESCRIPTION
## Summary
- bump the changed crate versions and update workspace dependency pins for the next coordinated alpha release
- refresh workspace/pathfinder/types release notes for the current parity state
- add a manual publish workflow plus repo-owned publish script for ordered crates.io releases

## Validation
- cargo fmt --all
- cargo check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test
- ./scripts/publish-crates.sh --dry-run