### PR TITLE
docs: add agent guidance and parity plans index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# AGENTS.md
+
+Guidance for AI agents and contributors working in this repository.
+
+## Project purpose
+
+`circles-rs` is a Rust workspace that ports the non-web/backend-relevant parts of the official Circles TypeScript SDK while keeping the Rust API idiomatic. The workspace is alpha-quality: preserve compatibility where possible, but expect API refinement while parity work continues.
+
+The current application-level entrypoint is `circles-sdk`; lower-level crates remain usable for direct RPC, pathfinding, transfer planning, utilities, shared types, and generated ABIs.
+
+## Crate layout
+
+- `crates/sdk` — high-level orchestrator, typed avatars, registration, profile integration, runners, invitation/referral helpers.
+- `crates/rpc` — Circles JSON-RPC client, pagination, event parsing/subscriptions.
+- `crates/pathfinder` — flow matrix/pathfinding helpers and contract-preparation utilities.
+- `crates/transfers` — transfer/replenish/group-token transaction planning.
+- `crates/profiles` — profile service client.
+- `crates/types` — shared response/config/domain types.
+- `crates/utils` — demurrage/inflation/day-index conversion utilities.
+- `crates/abis` — generated contract bindings.
+
+## Source-of-truth references
+
+For TypeScript SDK parity work, use these references:
+
+- Official TypeScript SDK repo: <https://github.com/aboutcircles/circles-sdk>
+- Rust repo milestone: <https://github.com/deluXtreme/circles-rs/milestone/1>
+- Active parity issue set:
+  - [#44 — V1 → V2 migration](https://github.com/deluXtreme/circles-rs/issues/44)
+  - [#45 — ERC20/ERC1155 wrapper operations](https://github.com/deluXtreme/circles-rs/issues/45)
+  - [#46 — profile service search](https://github.com/deluXtreme/circles-rs/issues/46)
+  - [#47 — CMG/group-specific methods](https://github.com/deluXtreme/circles-rs/issues/47)
+  - [#48 — TS-to-Rust convenience aliases and docs](https://github.com/deluXtreme/circles-rs/issues/48)
+  - [#49 — SDK parity confidence suite](https://github.com/deluXtreme/circles-rs/issues/49)
+  - [#50 — AGENTS.md and parity plans index](https://github.com/deluXtreme/circles-rs/issues/50)
+
+When issue text and repo docs disagree, inspect current code and the linked TypeScript SDK before implementing. Update docs as part of parity PRs when the status changes.
+
+## Scope rules for parity work
+
+- Count backend/CLI/server functionality.
+- Do not count browser-specific behavior unless an issue explicitly asks for it.
+- Excluded by default:
+  - browser provider execution
+  - Safe App UI execution
+  - frontend-only package behavior
+- Included by default:
+  - read-only RPC/data/profile behavior
+  - pathfinder and flow-matrix behavior
+  - transfer/replenish/wrapper planning
+  - EOA and non-browser Safe runner behavior
+  - transaction planning and calldata encoding
+  - migration, wrapper, CMG/group, profile-search, and SDK ergonomic parity
+
+## Development rules
+
+### Prefer thin vertical PRs
+
+Do not implement an entire epic in one PR. For example, migration parity should be split into configuration/ABI access, read-only eligibility, planning, execution, and docs/examples.
+
+Each PR should:
+
+- link an issue with `Closes #...` or `Refs #...`
+- state the TypeScript SDK method(s) it covers
+- state the Rust method(s) it adds or changes
+- include tests or explicitly explain why tests are not applicable
+- keep write execution as thin wrappers over planning helpers where possible
+
+### Use test-driven development for behavior changes
+
+For new behavior or bug fixes:
+
+1. Add a failing test first.
+2. Run the targeted test and verify it fails for the expected reason.
+3. Implement the smallest change that passes.
+4. Re-run the targeted test.
+5. Run the relevant crate/workspace checks.
+
+Documentation-only PRs do not need failing tests, but they should still run cheap formatting/inspection commands where practical.
+
+### Keep write paths safe and plan-first
+
+For transaction-writing parity work:
+
+- Add planning helpers before execution helpers.
+- Assert `PreparedTransaction` target, value, selector, and important calldata arguments.
+- Add missing-runner tests for SDK methods that require a runner.
+- Add mock-runner/pass-through tests for execution helpers.
+- Never make live write tests run by default.
+
+## Standard validation commands
+
+Use the most specific command that proves your change, then run broader checks before opening a PR.
+
+Common commands:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo doc --workspace --all-features --no-deps
+```
+
+For smaller iterations:
+
+```bash
+cargo test -p circles-sdk
+cargo test -p circles-rpc
+cargo test -p circles-pathfinder
+cargo test -p circles-transfers
+cargo test -p circles-profiles
+```
+
+If local OpenSSL development files are missing, `openssl-sys` may fail to build. In that case, note the local blocker in the PR/review and rely on GitHub Actions for full workspace verification.
+
+## Live test policy
+
+Live tests are opt-in only. They must skip cleanly unless the required environment variables are set.
+
+Common live-test variables:
+
+```bash
+RUN_LIVE=1
+LIVE_AVATAR=0x...
+CIRCLES_RPC_URL=https://...
+CIRCLES_CHAIN_RPC_URL=https://...
+CIRCLES_PATHFINDER_URL=https://...
+CIRCLES_PROFILE_URL=https://...
+```
+
+Profile-service live tests may also use:
+
+```bash
+RUN_LIVE_PROFILE_TESTS=1
+PROFILE_CID=...
+```
+
+Rules:
+
+- Read-only live tests may be ignored/gated.
+- Write-capable live tests must be separately gated and clearly documented.
+- Do not require secrets for default CI.
+- Do not print private keys, bearer tokens, or sensitive wallet material.
+
+## Plans
+
+Repository-local implementation plans live under [`docs/plans/`](docs/plans/). GitHub issues remain the source of truth for active work and review status; checked-in plans should summarize, link, and preserve execution context rather than duplicate issue bodies wholesale.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 - Generate docs with `cargo doc --workspace --all-features --no-deps`.
 - `crates/sdk/README.md` is the best starting point for application integration.
+- `AGENTS.md` contains contributor/agent guidance for parity work, validation, and safe live-test rules.
+- `docs/plans/` contains repo-local implementation plan indexes, including the current non-web TypeScript SDK parity roadmap.
 - Per-crate READMEs cover focused examples and feature notes.
 
 ## Examples

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,64 @@
+# Plans
+
+This directory holds repository-local implementation plans for `circles-rs`.
+
+GitHub issues are still the source of truth for active work, assignment, status, and review. Plans here should preserve implementation context, contributor/agent instructions, and cross-issue sequencing without duplicating long issue bodies in full.
+
+## Current active roadmap
+
+- Milestone: [TypeScript SDK parity: non-web](https://github.com/deluXtreme/circles-rs/milestone/1)
+- Roadmap index: [`ts-sdk-parity-non-web.md`](ts-sdk-parity-non-web.md)
+
+## Plan naming
+
+Use stable, dated names:
+
+```text
+YYYY-MM-DD-short-topic.md
+```
+
+For durable roadmap indexes, use a descriptive name without a date, for example:
+
+```text
+ts-sdk-parity-non-web.md
+```
+
+## Recommended plan format
+
+```markdown
+# Plan: short title
+
+## Goal
+
+One or two sentences describing the desired outcome.
+
+## Scope
+
+What is included and, just as importantly, what is excluded.
+
+## References
+
+- GitHub issue(s)
+- TypeScript SDK file/method references
+- Rust target files
+
+## Execution steps
+
+Small, reviewable PR-sized steps.
+
+## Validation
+
+Commands and tests that prove the work.
+
+## Safety notes
+
+For write-capable SDK work, describe dry-run/planning behavior, runner requirements, and live-test gates.
+```
+
+## Planning rules
+
+- Prefer bite-sized PR plans over monolithic epics.
+- For behavior changes, write tests first and verify they fail before implementation.
+- For write-capable methods, plan transaction construction separately from execution.
+- Link plans from PRs when they contain relevant context.
+- Update or archive plans when implementation diverges materially.

--- a/docs/plans/ts-sdk-parity-non-web.md
+++ b/docs/plans/ts-sdk-parity-non-web.md
@@ -1,0 +1,90 @@
+# TypeScript SDK parity: non-web
+
+Roadmap index for backend/CLI/server parity with the official Circles TypeScript SDK.
+
+- Milestone: [TypeScript SDK parity: non-web](https://github.com/deluXtreme/circles-rs/milestone/1)
+- TypeScript SDK reference: <https://github.com/aboutcircles/circles-sdk>
+- Rust SDK repo: <https://github.com/deluXtreme/circles-rs>
+
+## Scope
+
+Included:
+
+- RPC/data reads
+- profile service behavior
+- pathfinder and flow-matrix behavior
+- transfer/replenish/group-token planning
+- wrapper operation planning/execution
+- EOA and non-browser Safe runner behavior
+- V1 → V2 migration behavior
+- CMG/group-specific backend methods
+- TS-to-Rust ergonomic aliases where they wrap existing behavior honestly
+
+Excluded unless a specific issue says otherwise:
+
+- browser-provider execution
+- Safe App UI execution
+- frontend-only package behavior
+
+## Issues
+
+| Issue | Area | Priority | Status label | Notes |
+| --- | --- | --- | --- | --- |
+| [#44](https://github.com/deluXtreme/circles-rs/issues/44) | V1 → V2 migration | High | `status:ready` | Largest missing non-web feature. Start with config/ABI access, then read-only eligibility, then planning, then execution. |
+| [#45](https://github.com/deluXtreme/circles-rs/issues/45) | ERC20/ERC1155 wrapper operations | High | `status:ready` | Add plan-first wrapper operations and direct token transfer helpers. |
+| [#46](https://github.com/deluXtreme/circles-rs/issues/46) | Profile service search | Medium | `status:backlog` | Fill `circles-profiles` search/get-many parity. |
+| [#47](https://github.com/deluXtreme/circles-rs/issues/47) | CMG/group-specific methods | Medium | `status:backlog` | Decide type shape, then add read/write planning/execution helpers. |
+| [#48](https://github.com/deluXtreme/circles-rs/issues/48) | Convenience aliases and docs | Medium | `status:backlog` | Add honest TS-to-Rust mapping and thin aliases only where semantics match. |
+| [#49](https://github.com/deluXtreme/circles-rs/issues/49) | SDK parity confidence suite | Medium | `status:backlog` | Add validation policy, mock runner helpers, golden fixture conventions, and coverage visibility. |
+| [#50](https://github.com/deluXtreme/circles-rs/issues/50) | Repo hygiene | Medium | `status:ready` | Add `AGENTS.md` and this plans index. |
+
+## Recommended sequence
+
+1. Finish [#50](https://github.com/deluXtreme/circles-rs/issues/50) so agents and contributors have stable repo-local guidance.
+2. Improve [#49](https://github.com/deluXtreme/circles-rs/issues/49) so future parity work has clear validation rules.
+3. Start [#44](https://github.com/deluXtreme/circles-rs/issues/44) with migration config/ABI access only.
+4. Add migration read-only eligibility (`can_self_migrate`).
+5. Add migration planning helpers.
+6. Add migration execution helpers as thin runner-backed wrappers.
+7. Work through wrapper/profile/CMG parity in thin vertical PRs.
+
+## PR checklist for parity work
+
+```markdown
+## TS parity
+
+- [ ] TypeScript SDK method(s):
+- [ ] Rust SDK method(s):
+- [ ] Coverage status: Covered / Partial / Missing follow-up
+
+## Tests
+
+- [ ] Failing test observed before implementation, or docs-only PR
+- [ ] Targeted tests pass
+- [ ] Edge/error cases covered
+
+## Write-capable behavior, if applicable
+
+- [ ] Planning helper test asserts target/value/calldata selector
+- [ ] Missing-runner behavior tested
+- [ ] Mock-runner/pass-through execution tested
+- [ ] Live write behavior is not run by default
+
+## Commands
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] targeted `cargo test ...`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+```
+
+## Notes for migration work
+
+The migration epic should stay plan-first and safety-first:
+
+1. expose config/ABI access without executing anything;
+2. add read-only eligibility checks;
+3. build transaction plans;
+4. execute plans through existing runner abstractions only after planning behavior is reviewed.
+
+This keeps Safe/EOA behavior reviewable and avoids coupling migration logic to a specific wallet transport.


### PR DESCRIPTION
## Summary

- Adds root `AGENTS.md` with contributor/agent guidance for crate layout, parity scope, TDD expectations, validation commands, and live-test safety rules.
- Adds `docs/plans/README.md` with plan conventions.
- Adds `docs/plans/ts-sdk-parity-non-web.md` as a repo-local index for the TypeScript SDK non-web parity milestone/issues.
- Links the new guidance from the root README.

Closes #50

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`

Docs-only change; no Rust behavior changed.
