### PR TITLE
docs: add parity validation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ For transaction-writing parity work:
 
 ## Standard validation commands
 
-Use the most specific command that proves your change, then run broader checks before opening a PR.
+Detailed validation policy lives in [`docs/parity-validation.md`](docs/parity-validation.md). Use the most specific command that proves your change, then run broader checks before opening a PR.
 
 Common commands:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `crates/sdk/README.md` is the best starting point for application integration.
 - `AGENTS.md` contains contributor/agent guidance for parity work, validation, and safe live-test rules.
 - `docs/plans/` contains repo-local implementation plan indexes, including the current non-web TypeScript SDK parity roadmap.
+- `docs/parity-validation.md` describes the validation policy for TypeScript SDK parity work, golden fixtures, live-test gates, and write-path testing expectations.
 - Per-crate READMEs cover focused examples and feature notes.
 
 ## Examples

--- a/docs/parity-validation.md
+++ b/docs/parity-validation.md
@@ -1,0 +1,214 @@
+# Parity validation
+
+Validation policy for TypeScript SDK parity work in `circles-rs`.
+
+This document is intentionally conservative: parity work should be easy to review, safe by default, and grounded in tests or fixtures that make TypeScript-to-Rust behavior differences visible.
+
+## Goals
+
+- Keep default CI deterministic and secret-free.
+- Add explicit validation layers for non-web TypeScript SDK parity.
+- Prefer planning/dry-run assertions before transaction execution.
+- Make live checks opt-in and safe by default.
+- Give contributors a standard PR checklist for parity work.
+
+## Default CI validation
+
+The current CI should continue to run the core Rust checks:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+cargo build --all
+```
+
+For local or future CI expansion, prefer the workspace-explicit form:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo build --workspace
+cargo doc --workspace --all-features --no-deps
+```
+
+If local OpenSSL development files are missing, crates that depend on `openssl-sys` may fail to compile. In that case, document the local blocker and rely on GitHub Actions for full workspace verification.
+
+## Validation layers
+
+### Layer 1 — Unit tests
+
+Use unit tests for deterministic local behavior:
+
+- demurrage/inflation conversion
+- day-index calculations
+- config defaults
+- URL construction
+- serde request/response decoding
+- path/flow math
+- token aggregation
+- error mapping
+
+These should run in default CI and must not require network access or secrets.
+
+### Layer 2 — Prepared transaction tests
+
+Write-capable SDK behavior should be tested at the planning layer first.
+
+For every new transaction-planning helper, assert:
+
+- target address
+- value
+- calldata selector
+- important calldata arguments
+- ordering inside batches
+
+Planning tests should not require a runner, private key, network access, or live chain state.
+
+### Layer 3 — Runner behavior tests
+
+For SDK methods that execute transactions through a `ContractRunner`, add tests for:
+
+- `SdkError::MissingRunner` when no runner is configured
+- execution methods passing planned transactions through unchanged
+- batch order preservation
+- error propagation from the runner
+
+Prefer reusable mock-runner helpers over repeated ad hoc mocks.
+
+### Layer 4 — TypeScript golden fixtures
+
+Do not require Node/TypeScript execution in normal Rust CI. Instead, commit curated fixtures generated from the official TypeScript SDK and compare Rust output against them.
+
+Recommended fixture areas:
+
+- conversion/demurrage/inflation cases
+- pathfinder packing and flow-matrix transformations
+- wrapped-token total helpers
+- transfer/replenish transaction plan shapes
+- migration transaction plan shapes
+- profile service request/response shapes
+- ABI calldata selectors and arguments for planned writes
+
+A fixture should record:
+
+- TypeScript SDK repository URL
+- TypeScript SDK commit
+- package/version if relevant
+- command or script used to generate it
+- normalization rules, if any
+
+See [`fixtures/ts-sdk/README.md`](../fixtures/ts-sdk/README.md).
+
+### Layer 5 — Optional live read tests
+
+Live read tests are useful but must be opt-in and ignored/gated by default.
+
+Common environment variables:
+
+```bash
+RUN_LIVE=1
+LIVE_AVATAR=0x...
+CIRCLES_RPC_URL=https://...
+CIRCLES_CHAIN_RPC_URL=https://...
+CIRCLES_PATHFINDER_URL=https://...
+CIRCLES_PROFILE_URL=https://...
+```
+
+Profile-service tests may also use:
+
+```bash
+RUN_LIVE_PROFILE_TESTS=1
+PROFILE_CID=...
+```
+
+Rules:
+
+- Live read tests should skip cleanly when variables are missing.
+- Live read tests must not mutate chain or profile state unless explicitly documented.
+- Default CI must not require live endpoints.
+
+### Layer 6 — Optional live write tests
+
+Live write tests are allowed only as explicit, separately gated tests.
+
+Rules:
+
+- Never run live writes by default.
+- Require a dedicated environment flag beyond `RUN_LIVE=1`.
+- Document expected side effects.
+- Use test-only wallets/accounts.
+- Never print private keys, bearer tokens, seed phrases, or wallet material.
+- Prefer local/anvil tests before live writes.
+
+## Coverage visibility
+
+Coverage is useful as a signal, not an initial gate.
+
+Recommended first step:
+
+```bash
+cargo install cargo-llvm-cov
+cargo llvm-cov --workspace --all-features --summary-only
+```
+
+Do not enforce a hard percentage until baseline coverage is known. Start by publishing or recording the summary so coverage gaps are visible.
+
+## Parity PR checklist
+
+Every parity PR should include a checklist like this:
+
+```markdown
+## TS parity
+
+- [ ] TypeScript SDK method(s):
+- [ ] Rust SDK method(s):
+- [ ] Coverage status: Covered / Partial / Follow-up required
+- [ ] Browser/web behavior excluded or explicitly scoped
+
+## Tests
+
+- [ ] Failing test observed before implementation, or docs-only PR
+- [ ] Targeted tests pass
+- [ ] Edge/error cases covered
+- [ ] Golden fixture added/updated, or reason documented
+
+## Write-capable behavior, if applicable
+
+- [ ] Planning helper test asserts target/value/calldata selector
+- [ ] Important calldata arguments tested
+- [ ] Missing-runner behavior tested
+- [ ] Mock-runner/pass-through execution tested
+- [ ] Live write behavior is not run by default
+
+## Commands
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace`
+- [ ] targeted `cargo test ...`
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- [ ] CI green
+```
+
+## Validation expectations by work type
+
+| Work type | Required validation |
+| --- | --- |
+| Docs only | `git diff --check`, optional `cargo fmt --all -- --check` |
+| Pure logic | failing unit test, targeted test, workspace check where practical |
+| RPC/profile decoding | fixture decode test and error/empty case |
+| URL/query construction | unit test for encoded URL/body shape |
+| Transaction planning | prepared transaction target/value/selector/arg assertions |
+| Execution wrapper | missing-runner test plus mock-runner pass-through test |
+| Live read helper | ignored/gated live test if deterministic fixture coverage is not enough |
+| Live write helper | explicit opt-in live/anvil test plan; never default CI |
+
+## Recommended first validation PRs
+
+1. Add this policy document and fixture convention.
+2. Add reusable prepared-transaction assertion helpers.
+3. Add reusable mock-runner test helpers.
+4. Add initial TypeScript golden fixtures for converter/pathfinder behavior.
+5. Add coverage summary job or documented `cargo-llvm-cov` workflow.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,6 +8,7 @@ GitHub issues are still the source of truth for active work, assignment, status,
 
 - Milestone: [TypeScript SDK parity: non-web](https://github.com/deluXtreme/circles-rs/milestone/1)
 - Roadmap index: [`ts-sdk-parity-non-web.md`](ts-sdk-parity-non-web.md)
+- Validation policy: [`../parity-validation.md`](../parity-validation.md)
 
 ## Plan naming
 

--- a/docs/plans/ts-sdk-parity-non-web.md
+++ b/docs/plans/ts-sdk-parity-non-web.md
@@ -35,7 +35,7 @@ Excluded unless a specific issue says otherwise:
 | [#46](https://github.com/deluXtreme/circles-rs/issues/46) | Profile service search | Medium | `status:backlog` | Fill `circles-profiles` search/get-many parity. |
 | [#47](https://github.com/deluXtreme/circles-rs/issues/47) | CMG/group-specific methods | Medium | `status:backlog` | Decide type shape, then add read/write planning/execution helpers. |
 | [#48](https://github.com/deluXtreme/circles-rs/issues/48) | Convenience aliases and docs | Medium | `status:backlog` | Add honest TS-to-Rust mapping and thin aliases only where semantics match. |
-| [#49](https://github.com/deluXtreme/circles-rs/issues/49) | SDK parity confidence suite | Medium | `status:backlog` | Add validation policy, mock runner helpers, golden fixture conventions, and coverage visibility. |
+| [#49](https://github.com/deluXtreme/circles-rs/issues/49) | SDK parity confidence suite | Medium | `status:in-progress` | Add validation policy, mock runner helpers, golden fixture conventions, and coverage visibility. See [`../parity-validation.md`](../parity-validation.md). |
 | [#50](https://github.com/deluXtreme/circles-rs/issues/50) | Repo hygiene | Medium | `status:ready` | Add `AGENTS.md` and this plans index. |
 
 ## Recommended sequence

--- a/fixtures/ts-sdk/README.md
+++ b/fixtures/ts-sdk/README.md
@@ -1,0 +1,63 @@
+# TypeScript SDK golden fixtures
+
+This directory is reserved for curated fixtures generated from the official Circles TypeScript SDK and consumed by Rust tests.
+
+The Rust workspace should not need to execute Node/TypeScript during normal CI. Instead, generate fixtures intentionally, commit them, and make Rust tests compare against the checked-in data.
+
+## Fixture metadata
+
+Every fixture or fixture group should document:
+
+- TypeScript SDK repository URL
+- TypeScript SDK commit SHA
+- package name/version, if relevant
+- generation command or script
+- input cases
+- normalization rules, if any
+
+Recommended metadata shape:
+
+```json
+{
+  "source": {
+    "repo": "https://github.com/aboutcircles/circles-sdk",
+    "commit": "<sha>",
+    "package": "@circles-sdk/sdk",
+    "version": "<version>"
+  },
+  "generated_by": "<script or command>",
+  "normalization": [
+    "lowercase Ethereum addresses",
+    "sort arrays by stable key before comparison"
+  ],
+  "cases": []
+}
+```
+
+## Good fixture candidates
+
+- converter/demurrage/inflation calculations
+- pathfinder packing and flow-matrix transformations
+- wrapped-token total helpers
+- transfer/replenish transaction plan shapes
+- V1 → V2 migration transaction plan shapes
+- profile service request/response shapes
+- ABI calldata selectors and important encoded arguments
+
+## Comparison rules
+
+Prefer exact equality when outputs are deterministic.
+
+Use normalization only for differences that are semantically irrelevant, for example:
+
+- address casing
+- object field ordering
+- stable sorting of unordered arrays
+
+Do not normalize away semantic differences such as amount changes, missing vertices, missing transaction calls, different calldata selectors, or different target addresses.
+
+## CI policy
+
+- Rust tests may read these fixtures in default CI.
+- Fixture generation scripts should not run in default CI unless the repository explicitly opts into a Node/TypeScript validation job.
+- Network-dependent fixture generation should be documented and reproducible, but not required for normal Rust CI.


### PR DESCRIPTION
## Summary

- Adds `docs/parity-validation.md` with the validation policy for TypeScript SDK parity work.
- Defines validation layers: unit tests, prepared transaction assertions, runner behavior tests, TypeScript golden fixtures, opt-in live read tests, and separately gated live write tests.
- Adds `fixtures/ts-sdk/README.md` to define the committed golden-fixture convention.
- Links the policy from `AGENTS.md`, the root README, and the plans index.

Refs #49

## Validation

- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`

Docs/scaffolding-only change; no Rust behavior changed.

## Note

This PR is stacked on #51 because it links into `AGENTS.md` and `docs/plans/` from that PR. It should be retargeted to `main` after #51 merges, or merged after #51.
