### PR TITLE
test: add TS converter golden fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -14,3 +14,6 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 num-bigint = "0.4"
 num-traits = "0.2"
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/utils/src/converter.rs
+++ b/crates/utils/src/converter.rs
@@ -163,21 +163,63 @@ mod tests {
         assert_eq!(day_from_timestamp(INFLATION_DAY_ZERO_UNIX), 0);
     }
 
+    #[derive(Debug, serde::Deserialize)]
+    struct ConverterFixture {
+        cases: Vec<ConverterCase>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct ConverterCase {
+        name: String,
+        timestamp: u64,
+        demurraged_atto_circles: String,
+        static_atto_circles: String,
+        roundtrip_demurraged_atto_circles: String,
+        v1_crc_atto: String,
+        ui_circles: f64,
+    }
+
     #[test]
-    fn matches_ts_fixture() {
-        // TS CirclesConverter: attoCirclesToAttoStaticCircles(1e18, ts=1700000000) -> 1250475269390674654
-        let ts = 1_700_000_000u64;
-        let dem = U256::from(1_000_000_000_000_000_000u64);
-        let static_val = atto_circles_to_atto_static_circles(dem, Some(ts));
-        let expected = U256::from(1_250_475_269_390_674_654u64);
-        let diff = if static_val > expected {
-            static_val - expected
-        } else {
-            expected - static_val
-        };
-        assert!(diff < U256::from(1_000u64));
-        let back = atto_static_circles_to_atto_circles(static_val, Some(ts));
-        let back_diff = if back > dem { back - dem } else { dem - back };
-        assert!(back_diff < U256::from(2u64));
+    fn matches_ts_golden_converter_fixture() {
+        let fixture: ConverterFixture = serde_json::from_str(include_str!(
+            "../../../fixtures/ts-sdk/converter-demurrage-inflation.json"
+        ))
+        .expect("fixture parses");
+
+        for case in fixture.cases {
+            let dem = U256::from_str_radix(&case.demurraged_atto_circles, 10)
+                .unwrap_or_else(|err| panic!("{} demurraged amount parses: {err}", case.name));
+            let expected_static = U256::from_str_radix(&case.static_atto_circles, 10)
+                .unwrap_or_else(|err| panic!("{} static amount parses: {err}", case.name));
+            let expected_roundtrip =
+                U256::from_str_radix(&case.roundtrip_demurraged_atto_circles, 10)
+                    .unwrap_or_else(|err| panic!("{} roundtrip amount parses: {err}", case.name));
+            let expected_crc = U256::from_str_radix(&case.v1_crc_atto, 10)
+                .unwrap_or_else(|err| panic!("{} crc amount parses: {err}", case.name));
+
+            assert_eq!(
+                atto_circles_to_atto_static_circles(dem, Some(case.timestamp)),
+                expected_static,
+                "{} demurraged -> static",
+                case.name
+            );
+            assert_eq!(
+                atto_static_circles_to_atto_circles(expected_static, Some(case.timestamp)),
+                expected_roundtrip,
+                "{} static -> demurraged",
+                case.name
+            );
+            assert_eq!(
+                atto_circles_to_atto_crc(dem, case.timestamp),
+                expected_crc,
+                "{} demurraged -> v1 crc",
+                case.name
+            );
+            assert!(
+                (atto_circles_to_circles(dem) - case.ui_circles).abs() <= 1e-12,
+                "{} demurraged -> UI circles",
+                case.name
+            );
+        }
     }
 }

--- a/docs/parity-validation.md
+++ b/docs/parity-validation.md
@@ -100,7 +100,7 @@ A fixture should record:
 - command or script used to generate it
 - normalization rules, if any
 
-See [`fixtures/ts-sdk/README.md`](../fixtures/ts-sdk/README.md).
+See [`fixtures/ts-sdk/README.md`](../fixtures/ts-sdk/README.md). The first committed fixture set is `converter-demurrage-inflation.json`, compared by `cargo test -p circles-utils matches_ts_golden_converter_fixture`.
 
 ### Layer 5 — Optional live read tests
 

--- a/fixtures/ts-sdk/README.md
+++ b/fixtures/ts-sdk/README.md
@@ -34,9 +34,20 @@ Recommended metadata shape:
 }
 ```
 
-## Good fixture candidates
+## Current fixtures
 
-- converter/demurrage/inflation calculations
+| Fixture | Source | Rust comparison test | Covers |
+| --- | --- | --- | --- |
+| [`converter-demurrage-inflation.json`](converter-demurrage-inflation.json) | `@circles-sdk/utils` `CirclesConverter` at `bdd94bd1f771335d8e678e823705a35dcac840cf` | `cargo test -p circles-utils matches_ts_golden_converter_fixture` | demurraged/static conversion, V1 CRC conversion, UI circle conversion |
+
+Regenerate the converter fixture with:
+
+```bash
+node fixtures/ts-sdk/scripts/generate-converter-fixture.mjs > fixtures/ts-sdk/converter-demurrage-inflation.json
+```
+
+## Good next fixture candidates
+
 - pathfinder packing and flow-matrix transformations
 - wrapped-token total helpers
 - transfer/replenish transaction plan shapes

--- a/fixtures/ts-sdk/converter-demurrage-inflation.json
+++ b/fixtures/ts-sdk/converter-demurrage-inflation.json
@@ -1,0 +1,52 @@
+{
+  "source": {
+    "repo": "https://github.com/aboutcircles/circles-sdk",
+    "commit": "bdd94bd1f771335d8e678e823705a35dcac840cf",
+    "package": "@circles-sdk/utils",
+    "version": "0.29.2",
+    "source_file": "packages/utils/src/circlesConverter.ts"
+  },
+  "generated_by": "node fixtures/ts-sdk/scripts/generate-converter-fixture.mjs",
+  "normalization": [
+    "BigInt outputs serialized as base-10 strings",
+    "Uses exact 1e36 CirclesConverter methods for demurrage/static conversion"
+  ],
+  "cases": [
+    {
+      "name": "epoch-day-zero-one-circle",
+      "timestamp": 1602720000,
+      "demurraged_atto_circles": "1000000000000000000",
+      "static_atto_circles": "1000000000000000000",
+      "roundtrip_demurraged_atto_circles": "1000000000000000000",
+      "v1_crc_atto": "3000000000000000000",
+      "ui_circles": 1
+    },
+    {
+      "name": "nov-2023-one-circle",
+      "timestamp": 1700000000,
+      "demurraged_atto_circles": "1000000000000000000",
+      "static_atto_circles": "1250475269390674743",
+      "roundtrip_demurraged_atto_circles": "999999999999999999",
+      "v1_crc_atto": "2434801889118657409",
+      "ui_circles": 1
+    },
+    {
+      "name": "nov-2023-fractional-six-decimals",
+      "timestamp": 1700000000,
+      "demurraged_atto_circles": "1234567890000000000",
+      "static_atto_circles": "1543796614828826903",
+      "roundtrip_demurraged_atto_circles": "1234567889999999999",
+      "v1_crc_atto": "3005928230817234837",
+      "ui_circles": 1.2345678900000001
+    },
+    {
+      "name": "jan-2026-large",
+      "timestamp": 1767225600,
+      "demurraged_atto_circles": "42000000000000000000000",
+      "static_atto_circles": "61311722318585096009756",
+      "roundtrip_demurraged_atto_circles": "41999999999999999999999",
+      "v1_crc_atto": "88516630974514942781186",
+      "ui_circles": 42000
+    }
+  ]
+}

--- a/fixtures/ts-sdk/scripts/generate-converter-fixture.mjs
+++ b/fixtures/ts-sdk/scripts/generate-converter-fixture.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Generate converter-demurrage-inflation.json from the official TypeScript SDK
+// CirclesConverter formulas at:
+// https://github.com/aboutcircles/circles-sdk/blob/bdd94bd1f771335d8e678e823705a35dcac840cf/packages/utils/src/circlesConverter.ts
+//
+// This script is intentionally dependency-free so fixture regeneration does not
+// require installing the full TypeScript workspace. Keep constants and formulas
+// byte-for-byte aligned with the source file and update the source commit below
+// whenever refreshing the fixture from a newer SDK revision.
+
+const SOURCE = {
+  repo: 'https://github.com/aboutcircles/circles-sdk',
+  commit: 'bdd94bd1f771335d8e678e823705a35dcac840cf',
+  package: '@circles-sdk/utils',
+  version: '0.29.2',
+  source_file: 'packages/utils/src/circlesConverter.ts',
+};
+
+const ONE_36 = 1_000_000_000_000_000_000_000_000_000_000_000_000n;
+const GAMMA_36 = 999_801_332_008_598_957_430_613_406_568_191_166n;
+const BETA_36 = 1_000_198_707_468_214_629_156_271_489_013_303_962n;
+const SECONDS_PER_DAY = 86_400n;
+const INFLATION_DAY_ZERO_UNIX = 1_602_720_000n;
+const ATTO_FACTOR = 1_000_000_000_000_000_000n;
+const V1_ACCURACY = 100_000_000n;
+const V1_INFLATION_PCT_NUM = 107n;
+const V1_INFLATION_PCT_DEN = 100n;
+const PERIOD_SEC = 31_556_952n;
+
+function mul36(a, b) {
+  return (a * b) / ONE_36;
+}
+
+function pow36(base36, exp) {
+  let result = ONE_36;
+  let base = base36;
+  let e = exp;
+
+  while (e > 0n) {
+    if ((e & 1n) === 1n) {
+      result = mul36(result, base);
+    }
+    base = mul36(base, base);
+    e >>= 1n;
+  }
+  return result;
+}
+
+function dayFromTimestamp(unixSeconds) {
+  return (unixSeconds - INFLATION_DAY_ZERO_UNIX) / SECONDS_PER_DAY;
+}
+
+function attoCirclesToCircles(atto) {
+  if (atto === 0n) return 0;
+
+  const whole = atto / ATTO_FACTOR;
+  const frac = atto % ATTO_FACTOR;
+  const maxSafeInt = BigInt(Number.MAX_SAFE_INTEGER);
+  if (whole > maxSafeInt || whole < -maxSafeInt) {
+    throw new RangeError('Atto value’s integer component exceeds JS double precision.');
+  }
+
+  return Number(whole) + Number(frac) / Number(ATTO_FACTOR);
+}
+
+function inflationaryToDemurrageExact(inflationary, day) {
+  const factor = pow36(GAMMA_36, day);
+  return (inflationary * factor) / ONE_36;
+}
+
+function demurrageToInflationaryExact(demurraged, day) {
+  const factor = pow36(BETA_36, day);
+  return (demurraged * factor) / ONE_36;
+}
+
+function attoCirclesToAttoStaticCirclesExact(demurraged, nowUnixSeconds) {
+  return demurrageToInflationaryExact(demurraged, dayFromTimestamp(nowUnixSeconds));
+}
+
+function attoStaticCirclesToAttoCirclesExact(staticCircles, nowUnixSeconds) {
+  return inflationaryToDemurrageExact(staticCircles, dayFromTimestamp(nowUnixSeconds));
+}
+
+function v1InflateFactor(periodIdx) {
+  if (periodIdx === 0n) return V1_ACCURACY;
+  return (V1_ACCURACY * V1_INFLATION_PCT_NUM ** periodIdx) / (V1_INFLATION_PCT_DEN ** periodIdx);
+}
+
+function attoCirclesToAttoCrc(demurraged, blockTimestampUtc) {
+  const secondsSinceEpoch = blockTimestampUtc - INFLATION_DAY_ZERO_UNIX;
+  const periodIdx = secondsSinceEpoch / PERIOD_SEC;
+  const secondsIntoPeriod = secondsSinceEpoch % PERIOD_SEC;
+  const factorCur = v1InflateFactor(periodIdx);
+  const factorNext = v1InflateFactor(periodIdx + 1n);
+  const rP = factorCur * (PERIOD_SEC - secondsIntoPeriod) + factorNext * secondsIntoPeriod;
+  return (demurraged * 3n * V1_ACCURACY * PERIOD_SEC) / rP;
+}
+
+const inputs = [
+  {
+    name: 'epoch-day-zero-one-circle',
+    timestamp: 1_602_720_000n,
+    demurraged_atto_circles: 1_000_000_000_000_000_000n,
+  },
+  {
+    name: 'nov-2023-one-circle',
+    timestamp: 1_700_000_000n,
+    demurraged_atto_circles: 1_000_000_000_000_000_000n,
+  },
+  {
+    name: 'nov-2023-fractional-six-decimals',
+    timestamp: 1_700_000_000n,
+    demurraged_atto_circles: 1_234_567_890_000_000_000n,
+  },
+  {
+    name: 'jan-2026-large',
+    timestamp: 1_767_225_600n,
+    demurraged_atto_circles: 42_000_000_000_000_000_000_000n,
+  },
+];
+
+const cases = inputs.map((input) => {
+  const staticAttoCircles = attoCirclesToAttoStaticCirclesExact(
+    input.demurraged_atto_circles,
+    input.timestamp
+  );
+
+  return {
+    name: input.name,
+    timestamp: Number(input.timestamp),
+    demurraged_atto_circles: input.demurraged_atto_circles.toString(),
+    static_atto_circles: staticAttoCircles.toString(),
+    roundtrip_demurraged_atto_circles: attoStaticCirclesToAttoCirclesExact(
+      staticAttoCircles,
+      input.timestamp
+    ).toString(),
+    v1_crc_atto: attoCirclesToAttoCrc(
+      input.demurraged_atto_circles,
+      input.timestamp
+    ).toString(),
+    ui_circles: attoCirclesToCircles(input.demurraged_atto_circles),
+  };
+});
+
+console.log(JSON.stringify({
+  source: SOURCE,
+  generated_by: 'node fixtures/ts-sdk/scripts/generate-converter-fixture.mjs',
+  normalization: [
+    'BigInt outputs serialized as base-10 strings',
+    'Uses exact 1e36 CirclesConverter methods for demurrage/static conversion',
+  ],
+  cases,
+}, null, 2));


### PR DESCRIPTION
## Summary

- Add the first committed TypeScript SDK golden fixture for `CirclesConverter` demurrage/static, V1 CRC, and UI conversion behavior.
- Add a dependency-free fixture generation script with source commit/package metadata.
- Compare the fixture from `circles-utils` tests and document the fixture coverage/regeneration command.

Closes #54

## TS parity

- TypeScript SDK method(s): `CirclesConverter.attoCirclesToAttoStaticCirclesExact`, `attoStaticCirclesToAttoCirclesExact`, `attoCirclesToAttoCrc`, `attoCirclesToCircles`
- Rust SDK method(s): `atto_circles_to_atto_static_circles`, `atto_static_circles_to_atto_circles`, `atto_circles_to_atto_crc`, `atto_circles_to_circles`
- Coverage status: Partial — establishes the fixture pattern with converter coverage; future fixture areas remain follow-ups.
- Browser/web behavior excluded.

## Tests

- [x] Failing test observed before adding fixture/dependency
- [x] Targeted tests pass
- [x] Golden fixture added with source metadata and generation command

## Commands

- [x] `node fixtures/ts-sdk/scripts/generate-converter-fixture.mjs > /tmp/generated-converter-fixture.json && diff -u fixtures/ts-sdk/converter-demurrage-inflation.json /tmp/generated-converter-fixture.json`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p circles-utils`
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
